### PR TITLE
Add CI workflow to test Ruby 3.1-4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "4.0"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - run: bundle exec rake test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running `bundle exec rake test` on `ubuntu-latest` against Ruby 3.1, 3.2, 3.3, 3.4, and 4.0.
- Triggered on `pull_request`, with `fail-fast: false` so each Ruby version reports independently.

Resolves #12.

## Test plan
- [x] CI workflow runs on this PR and reports a job per Ruby version
- [x] All five matrix jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)