### PR TITLE
[codex] Add Playwright browser init scaffold

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,3 +41,4 @@ jobs:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
 
       - run: gem push "pkg/smartest-${RELEASE_TAG}.gem"
+      - run: gem push "pkg/smartest-playwright-${RELEASE_TAG}.gem"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Use `smartest/**/*_test.rb` as the default CLI glob so Smartest can coexist with Minitest files under `test/`.
 - Add gem packaging metadata and release tasks.
 - Add Docusaurus documentation.
+- Add the `smartest-playwright` gem with a Playwright init scaffold, fixture setup, matcher registration, and `smartest-playwright` CLI.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -843,15 +843,16 @@ Example commands:
 rake test
 rake build
 gem install ./pkg/smartest-0.1.0.gem
+gem install ./pkg/smartest-playwright-0.1.0.gem
 git tag 0.1.0
 git push origin 0.1.0
 ```
 
-`rake build` is provided by Bundler's gem tasks. Pushing a tag that matches
-`Smartest::VERSION`, such as `0.1.0` or `0.1.0.alpha1`, triggers the Deploy
-GitHub Actions workflow. The workflow runs `rake verify`, builds the gem, and
-publishes `pkg/smartest-$VERSION.gem` to RubyGems using the `RUBYGEMS_API_KEY`
-repository secret.
+`rake build` builds both `smartest` and `smartest-playwright` into `pkg/`.
+Pushing a tag that matches `Smartest::VERSION`, such as `0.1.0` or
+`0.1.0.alpha1`, triggers the Deploy GitHub Actions workflow. The workflow runs
+`rake verify`, builds the gems, and publishes them to RubyGems using the
+`RUBYGEMS_API_KEY` repository secret.
 
 ## Non-goals for the MVP
 
@@ -864,6 +865,5 @@ Do not implement these in the first version:
 - RSpec-compatible matcher ecosystem
 - snapshot testing
 - watch mode
-- browser automation integration
 
 These can be added after the core fixture model is stable.

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@
 
 source "https://rubygems.org"
 
-gemspec
+gemspec name: "smartest"
+gemspec name: "smartest-playwright"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,41 @@ Top 1 slowest test (0.00001 seconds, 100.0% of total time):
 1 test, 1 passed, 0 failed
 ```
 
+## Playwright quick start
+
+Add the Playwright extension gem to the test group:
+
+```ruby
+gem "smartest-playwright", group: :test
+```
+
+Then initialize the browser-test scaffold:
+
+```bash
+bundle install
+bundle exec smartest-playwright --init
+```
+
+The Playwright init command creates the normal Smartest helper, fixtures, and
+predicate matcher, then adds:
+
+```text
+smartest/fixtures/playwright_fixture.rb
+smartest/example_spec.rb
+```
+
+It also requires `smartest-playwright` from `smartest/test_helper.rb`, registers
+`PlaywrightFixture` and `PlaywrightMatcher`, adds
+`playwright-ruby-client` to the Gemfile test group, runs `bundle install`, runs
+`npm install playwright --save-dev`, and downloads Chromium with
+`npx playwright install chromium`.
+
+Run the generated browser example with:
+
+```bash
+bundle exec smartest smartest/example_spec.rb
+```
+
 ## Defining tests
 
 Use `test` at the top level:

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
-require "bundler/gem_tasks"
+require "fileutils"
+require_relative "lib/smartest/version"
 
 task :test do
   ruby "-Ilib", "exe/smartest"
+end
+
+desc "Build gem packages"
+task :build do
+  FileUtils.mkdir_p("pkg")
+  sh "gem build smartest.gemspec --output pkg/smartest-#{Smartest::VERSION}.gem"
+  sh "gem build smartest-playwright.gemspec --output pkg/smartest-playwright-#{Smartest::VERSION}.gem"
 end
 
 desc "Run tests and build the gem package"

--- a/SMARTEST_DESIGN.md
+++ b/SMARTEST_DESIGN.md
@@ -787,12 +787,22 @@ class Smartest::ExpectationTarget
     if matcher.respond_to?(:does_not_match?)
       return self if matcher.does_not_match?(@actual)
 
-      raise AssertionFailed, matcher.negated_failure_message
+      raise AssertionFailed, negated_failure_message_for(matcher)
     end
 
     return self unless matcher.matches?(@actual)
 
-    raise AssertionFailed, matcher.negated_failure_message
+    raise AssertionFailed, negated_failure_message_for(matcher)
+  end
+
+  private
+
+  def negated_failure_message_for(matcher)
+    return matcher.negated_failure_message if matcher.respond_to?(:negated_failure_message)
+    return matcher.failure_message_when_negated if matcher.respond_to?(:failure_message_when_negated)
+
+    description = matcher.respond_to?(:description) ? matcher.description : matcher.inspect
+    "expected #{@actual.inspect} not to #{description}"
   end
 end
 ```

--- a/documentation/docs/matchers.md
+++ b/documentation/docs/matchers.md
@@ -228,7 +228,7 @@ and implements:
 
 - `matches?(actual)`
 - `failure_message`
-- `negated_failure_message`
+- `negated_failure_message` or the RSpec-style `failure_message_when_negated`
 
 Plain objects that implement those methods still work with `expect(...).to`, but
 subclassing `Smartest::Matcher` gives custom matchers `.and` and `.or`

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -5,76 +5,70 @@ description: Drive Playwright browser tests from Smartest fixtures.
 
 # Browser Tests With Playwright
 
-Smartest does not need a separate browser-test API. Browser resources can be
-plain fixtures, and each test can request the Playwright `page` it needs with a
-keyword argument.
-
-This page assumes you understand the fixture model from [Fixtures](./fixtures.md):
-
-- use `suite_fixture` for expensive resources shared by the whole suite
-- use `fixture` for values that should be fresh for each test
-- use `cleanup` to release the resource owned by that fixture
-
-That maps naturally to Playwright:
+`smartest-playwright` adds a Playwright-focused init command and matcher module
+on top of Smartest. It keeps browser resources as ordinary Smartest fixtures:
 
 - the Playwright runtime is shared for the suite
 - the browser process is shared for the suite
 - each test gets a fresh browser context and page
 
-## Install Dependencies
+## Install
 
-Add Smartest and the Playwright Ruby client to the Gemfile:
+Add the extension gem to the test group:
 
-```ruby {4} title="Gemfile"
-source "https://rubygems.org"
-
-gem "smartest"
-gem "playwright-ruby-client"
+```ruby title="Gemfile"
+gem "smartest-playwright", group: :test
 ```
 
-Add Playwright to `package.json` so the local Playwright CLI is available:
-
-```json title="package.json"
-{
-  "dependencies": {
-    "playwright": "^1.59.1"
-  }
-}
-```
-
-Install the dependencies and download Chromium:
+Install it and initialize the browser-test scaffold:
 
 ```bash
 bundle install
-npm install
-npx playwright install chromium
+bundle exec smartest-playwright --init
 ```
 
-## Load Playwright
+The init command runs the normal `smartest --init` scaffold, then:
 
-Require Playwright from `smartest/test_helper.rb` before loading fixture files:
+- creates `smartest/fixtures/playwright_fixture.rb`
+- creates `smartest/example_spec.rb`
+- requires `smartest-playwright` from `smartest/test_helper.rb`
+- registers `PlaywrightFixture` and `PlaywrightMatcher`
+- adds `gem "playwright-ruby-client", group: :test` to the Gemfile
+- runs `bundle install`
+- runs `npm install playwright --save-dev`
+- runs `npx playwright install chromium`
 
-```ruby {2,8-11} title="smartest/test_helper.rb"
+## Generated Helper
+
+The generated helper requires the extension before loading fixture files, then
+registers the Playwright fixture and matcher:
+
+```ruby {2,14-15} title="smartest/test_helper.rb"
 require "smartest/autorun"
-require "playwright"
+require "smartest-playwright"
 
 Dir[File.join(__dir__, "fixtures", "**", "*.rb")].sort.each do |fixture_file|
   require fixture_file
 end
 
+Dir[File.join(__dir__, "matchers", "**", "*.rb")].sort.each do |matcher_file|
+  require matcher_file
+end
+
 around_suite do |suite|
+  use_matcher PredicateMatcher
   use_fixture PlaywrightFixture
+  use_matcher PlaywrightMatcher
   suite.run
 end
 ```
 
-The generated helper already loads every file under `smartest/fixtures/`, so the
-Playwright fixture can live with the rest of the suite setup. Register it from an
-`around_suite` block in the helper so every browser test can request `page:`.
+`PlaywrightMatcher` includes `Playwright::Test::Matchers`, so Smartest
+expectations can use Playwright assertions such as `have_url` and `have_text`.
 
-## Define Playwright Fixtures
+## Generated Fixtures
 
-Put the browser lifecycle in a fixture class:
+The generated fixture class owns the browser lifecycle:
 
 ```ruby title="smartest/fixtures/playwright_fixture.rb"
 class PlaywrightFixture < Smartest::Fixture
@@ -82,13 +76,27 @@ class PlaywrightFixture < Smartest::Fixture
     runtime = Playwright.create(
       playwright_cli_executable_path: "./node_modules/.bin/playwright",
     )
-
     cleanup { runtime.stop }
     runtime.playwright
   end
 
   suite_fixture :browser do |playwright:|
-    browser = playwright.chromium.launch(headless: true)
+    browser_type = case ENV["BROWSER"]
+    when "firefox"
+      :firefox
+    when "webkit"
+      :webkit
+    else
+      :chromium
+    end
+
+    launch_options = {}
+    launch_options[:headless] = !%w[0 false].include?(ENV["HEADLESS"])
+    if (slow_mo = ENV["SLOW_MO"].to_i) > 0
+      launch_options[:slowMo] = slow_mo
+    end
+
+    browser = playwright.send(browser_type).launch(**launch_options)
     cleanup { browser.close }
     browser
   end
@@ -101,58 +109,32 @@ class PlaywrightFixture < Smartest::Fixture
 end
 ```
 
-The dependency chain is expressed with keyword arguments:
+Set `BROWSER=firefox` or `BROWSER=webkit` to use another browser type. Set
+`HEADLESS=0` or `HEADLESS=false` to show the browser, and set `SLOW_MO=250` to
+slow Playwright actions by 250 milliseconds.
 
-- `browser` depends on `playwright:`
-- `page` depends on `browser:`
-- tests depend on `page:`
+## Generated Test
 
-Smartest resolves that chain automatically. When a test asks for `page:`, it
-resolves `page`, then `browser`, then `playwright`.
+`smartest-playwright --init` creates a spec-style browser test:
 
-The two suite fixtures make browser startup cheap across the suite. The
-test-scoped `page` fixture creates a new browser context for each test, so
-cookies, local storage, and session state do not leak between tests.
-
-Cleanup follows the same scopes. Each test closes its browser context after the
-test finishes. After the full suite finishes, Smartest closes the browser and
-stops the Playwright runtime.
-
-## Write a Browser Test
-
-Request `page:` from the test file:
-
-```ruby title="smartest/rubygems_search_test.rb"
+```ruby title="smartest/example_spec.rb"
 require "test_helper"
 
 test("finds the smartest gem on RubyGems") do |page:|
   page.goto("https://rubygems.org/")
-  page.locator("input[name='query']").first.fill("smartest")
+  page.locator("input[name='query']").fill("smartest")
   page.keyboard.press("Enter")
-  page.wait_for_url(%r{/search})
 
-  page.locator("a[href='/gems/smartest']").first.click
-  page.wait_for_url("https://rubygems.org/gems/smartest")
-
-  owner_href = page.locator("a[href^='/profiles/']").first.get_attribute("href")
-  expect(owner_href).to eq("/profiles/YusukeIwaki")
+  page.locator("a[href='/gems/smartest']").click
+  expect(page).to have_url("https://rubygems.org/gems/smartest")
+  expect(page.locator(".versions")).to have_text("0.3.0.alpha1")
 end
 ```
 
-The test body receives an ordinary Playwright `Page` object. All navigation,
-locator, keyboard, and assertion setup can use the Playwright Ruby client API
-directly.
-
-## Run the Suite
-
-Run browser tests the same way as any other Smartest suite:
+Run the generated spec by passing its path to the Smartest CLI:
 
 ```bash
-bundle exec smartest
+bundle exec smartest smartest/example_spec.rb
 ```
-
-Because the test file requires `test_helper`, Smartest loads the Playwright
-fixture file, registers `PlaywrightFixture` from the helper, resolves `page:`,
-and runs the test.
 
 ![Playwright browser test running from Smartest](/img/playwright-browser-tests.gif)

--- a/documentation/docs/running-test-suites.md
+++ b/documentation/docs/running-test-suites.md
@@ -50,8 +50,8 @@ If no paths are passed, the CLI looks for:
 smartest/**/*_test.rb
 ```
 
-Smartest does not load `test/**/*_test.rb` by default, so a project can keep
-Minitest files under `test/` while using Smartest files under `smartest/`.
+Smartest does not load files from `test/` by default, so a project can keep
+Minitest files there while using Smartest files under `smartest/`.
 
 You can pass a single file:
 

--- a/exe/smartest-playwright
+++ b/exe/smartest-playwright
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "smartest-playwright"
+
+usage = <<~USAGE
+  Usage:
+    smartest-playwright --init
+    smartest-playwright --version
+    smartest-playwright --help
+
+  Initializes a Smartest browser-test scaffold with Playwright fixtures and matchers.
+USAGE
+
+begin
+  if ARGV.include?("--help") || ARGV.include?("-h")
+    puts usage
+    exit 0
+  end
+
+  if ARGV.include?("--version") || ARGV.include?("-v")
+    puts Smartest::Playwright::VERSION
+    exit 0
+  end
+
+  if ARGV.include?("--init")
+    exit Smartest::Playwright::InitGenerator.new.run
+  end
+
+  warn usage
+  exit 1
+rescue Exception => error
+  raise if Smartest.fatal_exception?(error)
+
+  warn "Error initializing Smartest Playwright:"
+  warn "#{error.class}: #{error.message}"
+  warn error.backtrace&.first
+  exit 1
+end

--- a/lib/smartest-playwright.rb
+++ b/lib/smartest-playwright.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "smartest/playwright"

--- a/lib/smartest/expectation_target.rb
+++ b/lib/smartest/expectation_target.rb
@@ -20,12 +20,22 @@ module Smartest
       if matcher.respond_to?(:does_not_match?)
         return self if matcher.does_not_match?(@actual)
 
-        raise AssertionFailed, matcher.negated_failure_message
+        raise AssertionFailed, negated_failure_message_for(matcher)
       end
 
       return self unless matcher.matches?(@actual)
 
-      raise AssertionFailed, matcher.negated_failure_message
+      raise AssertionFailed, negated_failure_message_for(matcher)
+    end
+
+    private
+
+    def negated_failure_message_for(matcher)
+      return matcher.negated_failure_message if matcher.respond_to?(:negated_failure_message)
+      return matcher.failure_message_when_negated if matcher.respond_to?(:failure_message_when_negated)
+
+      description = matcher.respond_to?(:description) ? matcher.description : matcher.inspect
+      "expected #{@actual.inspect} not to #{description}"
     end
   end
 end

--- a/lib/smartest/init_generator.rb
+++ b/lib/smartest/init_generator.rb
@@ -88,19 +88,23 @@ module Smartest
       RUBY
     }.freeze
 
-    def initialize(root: Dir.pwd, output: $stdout)
+    def initialize(root: Dir.pwd, output: $stdout, files: FILES, final_message: "Run your test suite with: bundle exec smartest")
       @root = root
       @output = output
+      @files = files
+      @final_message = final_message
     end
 
     def run
       create_directory("smartest")
       create_directory("smartest/fixtures")
       create_directory("smartest/matchers")
-      FILES.each { |path, contents| create_file(path, contents) }
+      @files.each { |path, contents| create_file(path, contents) }
 
-      @output.puts
-      @output.puts "Run your test suite with: bundle exec smartest"
+      if @final_message
+        @output.puts
+        @output.puts @final_message
+      end
 
       0
     end

--- a/lib/smartest/playwright.rb
+++ b/lib/smartest/playwright.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "smartest"
+require "playwright"
+require "playwright/test"
+
+require_relative "playwright/init_generator"
+
+module Smartest
+  module Playwright
+    VERSION = Smartest::VERSION
+  end
+end
+
+module PlaywrightMatcher
+  include ::Playwright::Test::Matchers
+end

--- a/lib/smartest/playwright/init_generator.rb
+++ b/lib/smartest/playwright/init_generator.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module Smartest
+  module Playwright
+    class InitGenerator
+      PLAYWRIGHT_FIXTURE = <<~RUBY
+        # frozen_string_literal: true
+
+        class PlaywrightFixture < Smartest::Fixture
+          suite_fixture :playwright do
+            runtime = Playwright.create(
+              playwright_cli_executable_path: "./node_modules/.bin/playwright",
+            )
+            cleanup { runtime.stop }
+            runtime.playwright
+          end
+
+          suite_fixture :browser do |playwright:|
+            browser_type = case ENV["BROWSER"]
+            when "firefox"
+              :firefox
+            when "webkit"
+              :webkit
+            else
+              :chromium
+            end
+
+            launch_options = {}
+            launch_options[:headless] = !%w[0 false].include?(ENV["HEADLESS"])
+            if (slow_mo = ENV["SLOW_MO"].to_i) > 0
+              launch_options[:slowMo] = slow_mo
+            end
+
+            browser = playwright.send(browser_type).launch(**launch_options)
+            cleanup { browser.close }
+            browser
+          end
+
+          fixture :page do |browser:|
+            context = browser.new_context
+            cleanup { context.close }
+            context.new_page
+          end
+        end
+      RUBY
+
+      EXAMPLE_SPEC = <<~RUBY
+        # frozen_string_literal: true
+
+        require "test_helper"
+
+        test("finds the smartest gem on RubyGems") do |page:|
+          page.goto("https://rubygems.org/")
+          page.locator("input[name='query']").fill("smartest")
+          page.keyboard.press("Enter")
+
+          page.locator("a[href='/gems/smartest']").click
+          expect(page).to have_url("https://rubygems.org/gems/smartest")
+          expect(page.locator(".versions")).to have_text("0.3.0.alpha1")
+        end
+      RUBY
+
+      INSTALL_COMMANDS = [
+        ["bundle", "install"],
+        ["npm", "install", "playwright", "--save-dev"],
+        ["npx", "playwright", "install", "chromium"]
+      ].freeze
+
+      def initialize(root: Dir.pwd, output: $stdout, command_runner: nil)
+        @root = root
+        @output = output
+        @command_runner = command_runner || method(:run_system_command)
+      end
+
+      def run
+        Smartest::InitGenerator.new(
+          root: @root,
+          output: @output,
+          files: smartest_files,
+          final_message: nil
+        ).run
+        create_file("smartest/fixtures/playwright_fixture.rb", PLAYWRIGHT_FIXTURE)
+        update_test_helper
+        update_gemfile
+        install_dependencies
+        @output.puts
+        @output.puts "Run your browser test suite with: bundle exec smartest smartest/example_spec.rb"
+
+        0
+      end
+
+      private
+
+      def smartest_files
+        Smartest::InitGenerator::FILES.each_with_object({}) do |(path, contents), files|
+          next if path == "smartest/example_test.rb"
+
+          files[path] = contents
+        end.merge("smartest/example_spec.rb" => EXAMPLE_SPEC)
+      end
+
+      def create_file(path, contents)
+        absolute_path = File.join(@root, path)
+
+        if File.exist?(absolute_path)
+          @output.puts "exist   #{path}"
+          return
+        end
+
+        FileUtils.mkdir_p(File.dirname(absolute_path))
+        File.write(absolute_path, contents)
+        @output.puts "create  #{path}"
+      end
+
+      def update_test_helper
+        path = File.join(@root, "smartest/test_helper.rb")
+        contents = File.read(path)
+        updated = ensure_smartest_playwright_required(contents)
+        updated = ensure_playwright_registered(updated)
+
+        return if updated == contents
+
+        File.write(path, updated)
+        @output.puts "update  smartest/test_helper.rb"
+      end
+
+      def ensure_smartest_playwright_required(contents)
+        return contents if require_present?(contents, "smartest-playwright")
+
+        if contents.match?(/^require ["']smartest\/autorun["']$/)
+          contents.sub(/^require ["']smartest\/autorun["']\n/, "\\0require \"smartest-playwright\"\n")
+        else
+          "require \"smartest-playwright\"\n#{contents}"
+        end
+      end
+
+      def require_present?(contents, feature)
+        contents.match?(/^require ["']#{Regexp.escape(feature)}["']$/)
+      end
+
+      def ensure_playwright_registered(contents)
+        missing_lines = []
+        missing_lines << "  use_fixture PlaywrightFixture\n" unless contents.include?("use_fixture PlaywrightFixture")
+        missing_lines << "  use_matcher PlaywrightMatcher\n" unless contents.include?("use_matcher PlaywrightMatcher")
+        return contents if missing_lines.empty?
+
+        if contents.include?("use_matcher PredicateMatcher")
+          contents.sub(/^(\s*use_matcher PredicateMatcher\n)/) do
+            "#{Regexp.last_match(1)}#{missing_lines.join}"
+          end
+        else
+          "#{contents.chomp}\n\naround_suite do |suite|\n#{missing_lines.join}  suite.run\nend\n"
+        end
+      end
+
+      def update_gemfile
+        path = File.join(@root, "Gemfile")
+        exists = File.exist?(path)
+        contents = exists ? File.read(path) : "source \"https://rubygems.org\"\n"
+
+        if contents.match?(/gem ["']playwright-ruby-client["']/)
+          @output.puts "exist   Gemfile playwright-ruby-client"
+          return
+        end
+
+        separator = contents.end_with?("\n") ? "" : "\n"
+        updated = "#{contents}#{separator}\ngem \"playwright-ruby-client\", group: :test\n"
+        File.write(path, updated)
+        @output.puts(exists ? "update  Gemfile" : "create  Gemfile")
+      end
+
+      def install_dependencies
+        INSTALL_COMMANDS.each do |command|
+          @output.puts "run     #{command.join(" ")}"
+          next if @command_runner.call(command, chdir: @root)
+
+          raise "command failed: #{command.join(" ")}"
+        end
+      end
+
+      def run_system_command(command, chdir:)
+        system(*command, chdir: chdir)
+      end
+    end
+  end
+end

--- a/smartest-playwright.gemspec
+++ b/smartest-playwright.gemspec
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+core = Gem::Specification.load(File.expand_path("smartest.gemspec", __dir__))
+
+Gem::Specification.new do |spec|
+  spec.name = "smartest-playwright"
+  spec.version = core.version
+  spec.authors = core.authors
+
+  spec.summary = "Playwright browser-test setup for Smartest."
+  spec.description = "smartest-playwright adds a Smartest init command, fixture scaffold, and Playwright matcher integration for browser tests."
+  spec.homepage = core.homepage
+  spec.license = core.license
+  spec.required_ruby_version = core.required_ruby_version
+
+  spec.metadata = core.metadata.merge(
+    "source_code_uri" => "https://github.com/YusukeIwaki/smartest/tree/main"
+  )
+
+  spec.files = Dir.chdir(__dir__) do
+    Dir.glob(
+      [
+        "LICENSE",
+        "README.md",
+        "exe/smartest-playwright",
+        "lib/smartest-playwright.rb",
+        "lib/smartest/playwright.rb",
+        "lib/smartest/playwright/**/*.rb",
+        "smartest-playwright.gemspec"
+      ]
+    )
+  end
+
+  spec.bindir = "exe"
+  spec.executables = ["smartest-playwright"]
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "playwright-ruby-client", ">= 1.59", "< 2.0"
+  spec.add_dependency "smartest", "= #{core.version}"
+end

--- a/smartest.gemspec
+++ b/smartest.gemspec
@@ -32,12 +32,13 @@ Gem::Specification.new do |spec|
         "README.md",
         "Rakefile",
         "SMARTEST_DESIGN.md",
-        "exe/*",
-        "lib/**/*.rb",
+        "exe/smartest",
+        "lib/smartest.rb",
+        "lib/smartest/**/*.rb",
         "smartest.gemspec",
         "smartest/**/*.rb"
       ]
-    )
+    ).reject { |path| path == "lib/smartest/playwright.rb" || path.start_with?("lib/smartest/playwright/") }
   end
 
   spec.bindir = "exe"

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "smartest/autorun"
+require "smartest-playwright"
 require "fileutils"
 require "stringio"
 require "open3"
@@ -266,6 +267,24 @@ test("rejects negated matcher composition") do
   end
 
   expect(error.message).to eq("not_to does not support matcher composition with .and or .or")
+end
+
+test("not_to supports RSpec-style failure_message_when_negated") do
+  matcher = Class.new do
+    def matches?(_actual)
+      true
+    end
+
+    def failure_message_when_negated
+      "expected negated failure message"
+    end
+  end
+
+  error = SmartestSelfTest.capture_error(Smartest::AssertionFailed) do
+    expect("value").not_to matcher.new
+  end
+
+  expect(error.message).to eq("expected negated failure message")
 end
 
 test("short-circuits or matcher composition") do
@@ -1981,4 +2000,84 @@ test("cli init does not overwrite existing scaffold files") do
     expect(File.read(fixture_path)).to eq("# custom fixture\n")
     expect(File.read(matcher_path)).to eq("# custom matcher\n")
   end
+end
+
+test("smartest-playwright init generates browser scaffold and installation commands") do
+  Dir.mktmpdir do |dir|
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "smartest-playwright", group: :test
+    RUBY
+
+    commands = []
+    output = StringIO.new
+    generator = Smartest::Playwright::InitGenerator.new(
+      root: dir,
+      output: output,
+      command_runner: ->(command, chdir:) {
+        commands << [command, chdir]
+        true
+      }
+    )
+
+    status = generator.run
+
+    expect(status).to eq(0)
+    expect(File.exist?(File.join(dir, "smartest/example_test.rb"))).to eq(false)
+    expect(File.read(File.join(dir, "smartest/example_spec.rb"))).to include("finds the smartest gem on RubyGems")
+    expect(File.read(File.join(dir, "smartest/example_spec.rb"))).to include('expect(page).to have_url("https://rubygems.org/gems/smartest")')
+    expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include("class PlaywrightFixture < Smartest::Fixture")
+    expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include('playwright_cli_executable_path: "./node_modules/.bin/playwright"')
+    expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include("launch_options[:slowMo] = slow_mo")
+
+    helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
+    expect(helper_contents).to include('require "smartest/autorun"')
+    expect(helper_contents).to include('require "smartest-playwright"')
+    expect(helper_contents).to include("use_matcher PredicateMatcher\n  use_fixture PlaywrightFixture\n  use_matcher PlaywrightMatcher\n  suite.run")
+
+    gemfile_contents = File.read(File.join(dir, "Gemfile"))
+    expect(gemfile_contents).to include('gem "playwright-ruby-client", group: :test')
+    expect(commands).to eq(
+      [
+        [["bundle", "install"], dir],
+        [["npm", "install", "playwright", "--save-dev"], dir],
+        [["npx", "playwright", "install", "chromium"], dir]
+      ]
+    )
+    expect(output.string).to include("run     bundle install")
+    expect(output.string).to include("run     npm install playwright --save-dev")
+    expect(output.string).to include("run     npx playwright install chromium")
+    expect(output.string).to include("Run your browser test suite with: bundle exec smartest smartest/example_spec.rb")
+  end
+end
+
+test("smartest-playwright executable prints help and version") do
+  stdout, stderr, status = Open3.capture3(
+    { "RUBYLIB" => File.expand_path("../lib", __dir__) },
+    "ruby",
+    File.expand_path("../exe/smartest-playwright", __dir__),
+    "--help"
+  )
+
+  expect(status.success?).to eq(true)
+  expect(stderr).to eq("")
+  expect(stdout).to include("smartest-playwright --init")
+
+  stdout, stderr, status = Open3.capture3(
+    { "RUBYLIB" => File.expand_path("../lib", __dir__) },
+    "ruby",
+    File.expand_path("../exe/smartest-playwright", __dir__),
+    "--version"
+  )
+
+  expect(status.success?).to eq(true)
+  expect(stderr).to eq("")
+  expect(stdout).to eq("#{Smartest::Playwright::VERSION}\n")
+end
+
+test("smartest-playwright defines PlaywrightMatcher") do
+  expect(PlaywrightMatcher).to be_a(Module)
+  expect(PlaywrightMatcher.instance_methods).to include(:have_url)
+  expect(PlaywrightMatcher.instance_methods).to include(:have_text)
 end


### PR DESCRIPTION
## Summary

Adds a sibling `smartest-playwright` gem to the repository without introducing Zeitwerk. The new gem provides `PlaywrightMatcher`, a `smartest-playwright --init` executable, and a Playwright-focused init generator that builds on the existing Smartest scaffold.

## Details

- Adds `smartest-playwright.gemspec`, `exe/smartest-playwright`, and `lib/smartest/playwright*` entrypoints.
- Generates `smartest/fixtures/playwright_fixture.rb` and `smartest/example_spec.rb` from `bundle exec smartest-playwright --init`.
- Updates generated `smartest/test_helper.rb` to require `smartest-playwright` and register `PlaywrightFixture` plus `PlaywrightMatcher`.
- Adds Gemfile / npm / Playwright browser install steps to the init flow.
- Keeps the generated browser example as `smartest/example_spec.rb`; docs and init output show running it explicitly with `bundle exec smartest smartest/example_spec.rb`.
- Keeps the core `smartest` gem package from including the Playwright extension files, and updates build/deploy tasks for both gems.
- Updates README, Docusaurus docs, development notes, design notes, and changelog for the new behavior.

## Validation

- `bundle exec rake test`
- `bundle exec rake build`
- `npm run build` from `documentation/`
