### PR TITLE
Add Playwright browser init scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Use `smartest/**/*_test.rb` as the default CLI glob so Smartest can coexist with Minitest files under `test/`.
 - Add gem packaging metadata and release tasks.
 - Add Docusaurus documentation.
+- Add `smartest --init-browser` with a Playwright init scaffold, fixture setup, matcher generation, and dependency installation.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -864,6 +864,5 @@ Do not implement these in the first version:
 - RSpec-compatible matcher ecosystem
 - snapshot testing
 - watch mode
-- browser automation integration
 
 These can be added after the core fixture model is stable.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ predicate matcher, then adds:
 ```text
 smartest/fixtures/playwright_fixture.rb
 smartest/matchers/playwright_matcher.rb
-smartest/example_spec.rb
+smartest/example_browser_test.rb
 ```
 
 It also registers `PlaywrightFixture` and `PlaywrightMatcher`, adds
@@ -153,7 +153,7 @@ It also registers `PlaywrightFixture` and `PlaywrightMatcher`, adds
 Run the generated browser example with:
 
 ```bash
-bundle exec smartest smartest/example_spec.rb
+bundle exec smartest smartest/example_browser_test.rb
 ```
 
 ## Defining tests

--- a/README.md
+++ b/README.md
@@ -127,6 +127,34 @@ Top 1 slowest test (0.00001 seconds, 100.0% of total time):
 1 test, 1 passed, 0 failed
 ```
 
+## Playwright quick start
+
+Initialize a browser-test scaffold:
+
+```bash
+bundle exec smartest --init-browser
+```
+
+The Playwright init command creates the normal Smartest helper, fixtures, and
+predicate matcher, then adds:
+
+```text
+smartest/fixtures/playwright_fixture.rb
+smartest/matchers/playwright_matcher.rb
+smartest/example_spec.rb
+```
+
+It also registers `PlaywrightFixture` and `PlaywrightMatcher`, adds
+`playwright-ruby-client` to the Gemfile test group, runs `bundle install`, runs
+`npm install playwright --save-dev`, and downloads Chromium with
+`npx playwright install chromium`.
+
+Run the generated browser example with:
+
+```bash
+bundle exec smartest smartest/example_spec.rb
+```
+
 ## Defining tests
 
 Use `test` at the top level:

--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ smartest/example_spec.rb
 
 It also registers `PlaywrightFixture` and `PlaywrightMatcher`, adds
 `playwright-ruby-client` to the Gemfile test group, runs `bundle install`, runs
+`npm init --yes` when no `package.json` exists yet, runs
 `npm install playwright --save-dev`, and downloads Chromium with
-`npx playwright install chromium`.
+`./node_modules/.bin/playwright install`.
 
 Run the generated browser example with:
 

--- a/SMARTEST_DESIGN.md
+++ b/SMARTEST_DESIGN.md
@@ -787,12 +787,22 @@ class Smartest::ExpectationTarget
     if matcher.respond_to?(:does_not_match?)
       return self if matcher.does_not_match?(@actual)
 
-      raise AssertionFailed, matcher.negated_failure_message
+      raise AssertionFailed, negated_failure_message_for(matcher)
     end
 
     return self unless matcher.matches?(@actual)
 
-    raise AssertionFailed, matcher.negated_failure_message
+    raise AssertionFailed, negated_failure_message_for(matcher)
+  end
+
+  private
+
+  def negated_failure_message_for(matcher)
+    return matcher.negated_failure_message if matcher.respond_to?(:negated_failure_message)
+    return matcher.failure_message_when_negated if matcher.respond_to?(:failure_message_when_negated)
+
+    description = matcher.respond_to?(:description) ? matcher.description : matcher.inspect
+    "expected #{@actual.inspect} not to #{description}"
   end
 end
 ```

--- a/documentation/docs/matchers.md
+++ b/documentation/docs/matchers.md
@@ -228,7 +228,7 @@ and implements:
 
 - `matches?(actual)`
 - `failure_message`
-- `negated_failure_message`
+- `negated_failure_message` or the RSpec-style `failure_message_when_negated`
 
 Plain objects that implement those methods still work with `expect(...).to`, but
 subclassing `Smartest::Matcher` gives custom matchers `.and` and `.or`

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -24,7 +24,7 @@ The init command runs the normal `smartest --init` scaffold, then:
 
 - creates `smartest/fixtures/playwright_fixture.rb`
 - creates `smartest/matchers/playwright_matcher.rb`
-- creates `smartest/example_spec.rb`
+- creates `smartest/example_browser_test.rb`
 - registers `PlaywrightFixture` and `PlaywrightMatcher`
 - adds `gem "playwright-ruby-client", group: :test` to the Gemfile
 - runs `bundle install`
@@ -122,9 +122,9 @@ slow Playwright actions by 250 milliseconds.
 
 ## Generated Test
 
-`smartest --init-browser` creates a spec-style browser test:
+`smartest --init-browser` creates a browser test:
 
-```ruby title="smartest/example_spec.rb"
+```ruby title="smartest/example_browser_test.rb"
 require "test_helper"
 
 test("finds the smartest gem on RubyGems") do |page:|
@@ -138,10 +138,10 @@ test("finds the smartest gem on RubyGems") do |page:|
 end
 ```
 
-Run the generated spec by passing its path to the Smartest CLI:
+Run the generated test by passing its path to the Smartest CLI:
 
 ```bash
-bundle exec smartest smartest/example_spec.rb
+bundle exec smartest smartest/example_browser_test.rb
 ```
 
 ![Playwright browser test running from Smartest](/img/playwright-browser-tests.gif)

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -5,37 +5,101 @@ description: Drive Playwright browser tests from Smartest fixtures.
 
 # Browser Tests With Playwright
 
-Smartest can generate a Playwright-focused browser-test scaffold. It keeps
-browser resources as ordinary Smartest fixtures:
+Smartest can scaffold a Playwright-powered browser-test setup. Once it is in
+place, you can write browser tests that look and feel like ordinary Smartest
+tests — just receive a `page:` fixture and drive it with the Playwright API.
 
-- the Playwright runtime is shared for the suite
-- the browser process is shared for the suite
-- each test gets a fresh browser context and page
+## Quick Start
 
-## Install
-
-Initialize the browser-test scaffold:
+### 1. Initialize the scaffold
 
 ```bash
 bundle exec smartest --init-browser
 ```
 
-The init command runs the normal `smartest --init` scaffold, then:
+This sets up everything needed to run Playwright browser tests: the
+`playwright-ruby-client` gem, the Playwright Node.js package and browsers, and
+example fixture / matcher / test files under `smartest/`.
+
+### 2. Run the generated example test
+
+```bash
+bundle exec smartest smartest/example_browser_test.rb
+```
+
+![Playwright browser test running from Smartest](/img/playwright-browser-tests.gif)
+
+### 3. Write your own browser test
+
+Inside any test file under `smartest/`, declare a test that takes the `page:`
+fixture. `page` is a Playwright `Page`, so the full Playwright Ruby API is
+available. Smartest expectations support Playwright matchers like `have_url`
+and `have_text`.
+
+```ruby title="smartest/example_browser_test.rb"
+require "test_helper"
+
+test("finds the smartest gem on RubyGems") do |page:|
+  page.goto("https://rubygems.org/")
+  page.locator("input[name='query']").fill("smartest")
+  page.keyboard.press("Enter")
+
+  page.locator("a[href='/gems/smartest']").click
+  expect(page).to have_url("https://rubygems.org/gems/smartest")
+  expect(page.locator(".versions")).to have_text("0.3.0.alpha1")
+end
+```
+
+Each test gets a fresh browser context and page; the Playwright runtime and
+browser process are shared across the suite.
+
+### 4. Control the browser via environment variables
+
+The scaffold reads three environment variables at launch time:
+
+| Variable   | Values                      | Effect                                                     |
+| ---------- | --------------------------- | ---------------------------------------------------------- |
+| `BROWSER`  | `chromium` (default), `firefox`, `webkit` | Which browser type to launch.                  |
+| `HEADLESS` | `1` / `true` (default), `0` / `false`     | Set to `0` or `false` to show the browser window. |
+| `SLOW_MO`  | integer (milliseconds)      | Slow each Playwright action by N ms. `0` (default) disables it. |
+
+Examples:
+
+```bash
+# Run with Firefox
+BROWSER=firefox bundle exec smartest smartest/example_browser_test.rb
+
+# Show the browser and slow it down so you can watch the test
+HEADLESS=0 SLOW_MO=250 bundle exec smartest smartest/example_browser_test.rb
+```
+
+That's everything you need to start writing browser tests. The rest of this
+page is for when you want to change how the scaffold behaves.
+
+---
+
+## Customization Points
+
+`smartest --init-browser` generates three Ruby files. They are ordinary
+Smartest fixtures and matchers — edit them freely to tune behavior.
+
+### What `--init-browser` generates
+
+On top of the normal `smartest --init` scaffold, the command:
 
 - creates `smartest/fixtures/playwright_fixture.rb`
 - creates `smartest/matchers/playwright_matcher.rb`
 - creates `smartest/example_browser_test.rb`
-- registers `PlaywrightFixture` and `PlaywrightMatcher`
-- adds `gem "playwright-ruby-client", group: :test` to the Gemfile
-- runs `bundle install`
+- registers `PlaywrightFixture` and `PlaywrightMatcher` in `test_helper.rb`
+- adds `gem "playwright-ruby-client", group: :test` to the Gemfile and runs `bundle install`
 - runs `npm init --yes` when no `package.json` exists yet
 - runs `npm install playwright --save-dev`
 - runs `./node_modules/.bin/playwright install`
 
-## Generated Helper
+### Test helper
 
 The generated helper loads fixture and matcher files, then registers the
-Playwright fixture and matcher:
+Playwright fixture and matcher for the suite:
 
 ```ruby {13-14} title="smartest/test_helper.rb"
 require "smartest/autorun"
@@ -56,24 +120,16 @@ around_suite do |suite|
 end
 ```
 
-`smartest --init-browser` generates the matcher module under
-`smartest/matchers/`:
+Add your own fixtures or matchers here, or replace `PlaywrightFixture` /
+`PlaywrightMatcher` with subclasses of your own.
 
-```ruby title="smartest/matchers/playwright_matcher.rb"
-require "playwright"
-require "playwright/test"
+### Browser lifecycle fixture
 
-module PlaywrightMatcher
-  include Playwright::Test::Matchers
-end
-```
-
-`PlaywrightMatcher` includes `Playwright::Test::Matchers`, so Smartest
-expectations can use Playwright assertions such as `have_url` and `have_text`.
-
-## Generated Fixtures
-
-The generated fixture class owns the browser lifecycle:
+The fixture class owns the Playwright runtime, the browser process, and the
+per-test page. This is where the `BROWSER` / `HEADLESS` / `SLOW_MO`
+environment variables are read — change this file to add launch options
+(viewport size, locale, custom args, …) or to change the per-test context
+(authentication state, recorded videos, …).
 
 ```ruby title="smartest/fixtures/playwright_fixture.rb"
 require "playwright"
@@ -116,32 +172,25 @@ class PlaywrightFixture < Smartest::Fixture
 end
 ```
 
-Set `BROWSER=firefox` or `BROWSER=webkit` to use another browser type. Set
-`HEADLESS=0` or `HEADLESS=false` to show the browser, and set `SLOW_MO=250` to
-slow Playwright actions by 250 milliseconds.
+Lifecycle summary:
 
-## Generated Test
+- `:playwright` and `:browser` are `suite_fixture`s — created once and reused.
+- `:page` is a regular `fixture` — created fresh for each test, with its own
+  `BrowserContext` so cookies and storage are isolated.
 
-`smartest --init-browser` creates a browser test:
+### Playwright matcher
 
-```ruby title="smartest/example_browser_test.rb"
-require "test_helper"
+The matcher module exposes Playwright's web-first assertions (`have_url`,
+`have_text`, `be_visible`, …) to Smartest's `expect(...).to ...` syntax:
 
-test("finds the smartest gem on RubyGems") do |page:|
-  page.goto("https://rubygems.org/")
-  page.locator("input[name='query']").fill("smartest")
-  page.keyboard.press("Enter")
+```ruby title="smartest/matchers/playwright_matcher.rb"
+require "playwright"
+require "playwright/test"
 
-  page.locator("a[href='/gems/smartest']").click
-  expect(page).to have_url("https://rubygems.org/gems/smartest")
-  expect(page.locator(".versions")).to have_text("0.3.0.alpha1")
+module PlaywrightMatcher
+  include Playwright::Test::Matchers
 end
 ```
 
-Run the generated test by passing its path to the Smartest CLI:
-
-```bash
-bundle exec smartest smartest/example_browser_test.rb
-```
-
-![Playwright browser test running from Smartest](/img/playwright-browser-tests.gif)
+Add your own matcher methods to this module if you want project-specific
+assertions on Playwright objects.

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -28,6 +28,7 @@ The init command runs the normal `smartest --init` scaffold, then:
 - registers `PlaywrightFixture` and `PlaywrightMatcher`
 - adds `gem "playwright-ruby-client", group: :test` to the Gemfile
 - runs `bundle install`
+- runs `npm init --yes` when no `package.json` exists yet
 - runs `npm install playwright --save-dev`
 - runs `./node_modules/.bin/playwright install`
 

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -5,90 +5,104 @@ description: Drive Playwright browser tests from Smartest fixtures.
 
 # Browser Tests With Playwright
 
-Smartest does not need a separate browser-test API. Browser resources can be
-plain fixtures, and each test can request the Playwright `page` it needs with a
-keyword argument.
-
-This page assumes you understand the fixture model from [Fixtures](./fixtures.md):
-
-- use `suite_fixture` for expensive resources shared by the whole suite
-- use `fixture` for values that should be fresh for each test
-- use `cleanup` to release the resource owned by that fixture
-
-That maps naturally to Playwright:
+Smartest can generate a Playwright-focused browser-test scaffold. It keeps
+browser resources as ordinary Smartest fixtures:
 
 - the Playwright runtime is shared for the suite
 - the browser process is shared for the suite
 - each test gets a fresh browser context and page
 
-## Install Dependencies
+## Install
 
-Add Smartest and the Playwright Ruby client to the Gemfile:
-
-```ruby {4} title="Gemfile"
-source "https://rubygems.org"
-
-gem "smartest"
-gem "playwright-ruby-client"
-```
-
-Add Playwright to `package.json` so the local Playwright CLI is available:
-
-```json title="package.json"
-{
-  "dependencies": {
-    "playwright": "^1.59.1"
-  }
-}
-```
-
-Install the dependencies and download Chromium:
+Initialize the browser-test scaffold:
 
 ```bash
-bundle install
-npm install
-npx playwright install chromium
+bundle exec smartest --init-browser
 ```
 
-## Load Playwright
+The init command runs the normal `smartest --init` scaffold, then:
 
-Require Playwright from `smartest/test_helper.rb` before loading fixture files:
+- creates `smartest/fixtures/playwright_fixture.rb`
+- creates `smartest/matchers/playwright_matcher.rb`
+- creates `smartest/example_spec.rb`
+- registers `PlaywrightFixture` and `PlaywrightMatcher`
+- adds `gem "playwright-ruby-client", group: :test` to the Gemfile
+- runs `bundle install`
+- runs `npm install playwright --save-dev`
+- runs `./node_modules/.bin/playwright install`
 
-```ruby {2,8-11} title="smartest/test_helper.rb"
+## Generated Helper
+
+The generated helper loads fixture and matcher files, then registers the
+Playwright fixture and matcher:
+
+```ruby {13-14} title="smartest/test_helper.rb"
 require "smartest/autorun"
-require "playwright"
 
 Dir[File.join(__dir__, "fixtures", "**", "*.rb")].sort.each do |fixture_file|
   require fixture_file
 end
 
+Dir[File.join(__dir__, "matchers", "**", "*.rb")].sort.each do |matcher_file|
+  require matcher_file
+end
+
 around_suite do |suite|
+  use_matcher PredicateMatcher
   use_fixture PlaywrightFixture
+  use_matcher PlaywrightMatcher
   suite.run
 end
 ```
 
-The generated helper already loads every file under `smartest/fixtures/`, so the
-Playwright fixture can live with the rest of the suite setup. Register it from an
-`around_suite` block in the helper so every browser test can request `page:`.
+`smartest --init-browser` generates the matcher module under
+`smartest/matchers/`:
 
-## Define Playwright Fixtures
+```ruby title="smartest/matchers/playwright_matcher.rb"
+require "playwright"
+require "playwright/test"
 
-Put the browser lifecycle in a fixture class:
+module PlaywrightMatcher
+  include Playwright::Test::Matchers
+end
+```
+
+`PlaywrightMatcher` includes `Playwright::Test::Matchers`, so Smartest
+expectations can use Playwright assertions such as `have_url` and `have_text`.
+
+## Generated Fixtures
+
+The generated fixture class owns the browser lifecycle:
 
 ```ruby title="smartest/fixtures/playwright_fixture.rb"
+require "playwright"
+
 class PlaywrightFixture < Smartest::Fixture
   suite_fixture :playwright do
     runtime = Playwright.create(
       playwright_cli_executable_path: "./node_modules/.bin/playwright",
     )
-
     cleanup { runtime.stop }
     runtime.playwright
   end
 
   suite_fixture :browser do |playwright:|
-    browser = playwright.chromium.launch(headless: true)
+    browser_type = case ENV["BROWSER"]
+    when "firefox"
+      :firefox
+    when "webkit"
+      :webkit
+    else
+      :chromium
+    end
+
+    launch_options = {}
+    launch_options[:headless] = !%w[0 false].include?(ENV["HEADLESS"])
+    if (slow_mo = ENV["SLOW_MO"].to_i) > 0
+      launch_options[:slowMo] = slow_mo
+    end
+
+    browser = playwright.send(browser_type).launch(**launch_options)
     cleanup { browser.close }
     browser
   end
@@ -101,58 +115,32 @@ class PlaywrightFixture < Smartest::Fixture
 end
 ```
 
-The dependency chain is expressed with keyword arguments:
+Set `BROWSER=firefox` or `BROWSER=webkit` to use another browser type. Set
+`HEADLESS=0` or `HEADLESS=false` to show the browser, and set `SLOW_MO=250` to
+slow Playwright actions by 250 milliseconds.
 
-- `browser` depends on `playwright:`
-- `page` depends on `browser:`
-- tests depend on `page:`
+## Generated Test
 
-Smartest resolves that chain automatically. When a test asks for `page:`, it
-resolves `page`, then `browser`, then `playwright`.
+`smartest --init-browser` creates a spec-style browser test:
 
-The two suite fixtures make browser startup cheap across the suite. The
-test-scoped `page` fixture creates a new browser context for each test, so
-cookies, local storage, and session state do not leak between tests.
-
-Cleanup follows the same scopes. Each test closes its browser context after the
-test finishes. After the full suite finishes, Smartest closes the browser and
-stops the Playwright runtime.
-
-## Write a Browser Test
-
-Request `page:` from the test file:
-
-```ruby title="smartest/rubygems_search_test.rb"
+```ruby title="smartest/example_spec.rb"
 require "test_helper"
 
 test("finds the smartest gem on RubyGems") do |page:|
   page.goto("https://rubygems.org/")
-  page.locator("input[name='query']").first.fill("smartest")
+  page.locator("input[name='query']").fill("smartest")
   page.keyboard.press("Enter")
-  page.wait_for_url(%r{/search})
 
-  page.locator("a[href='/gems/smartest']").first.click
-  page.wait_for_url("https://rubygems.org/gems/smartest")
-
-  owner_href = page.locator("a[href^='/profiles/']").first.get_attribute("href")
-  expect(owner_href).to eq("/profiles/YusukeIwaki")
+  page.locator("a[href='/gems/smartest']").click
+  expect(page).to have_url("https://rubygems.org/gems/smartest")
+  expect(page.locator(".versions")).to have_text("0.3.0.alpha1")
 end
 ```
 
-The test body receives an ordinary Playwright `Page` object. All navigation,
-locator, keyboard, and assertion setup can use the Playwright Ruby client API
-directly.
-
-## Run the Suite
-
-Run browser tests the same way as any other Smartest suite:
+Run the generated spec by passing its path to the Smartest CLI:
 
 ```bash
-bundle exec smartest
+bundle exec smartest smartest/example_spec.rb
 ```
-
-Because the test file requires `test_helper`, Smartest loads the Playwright
-fixture file, registers `PlaywrightFixture` from the helper, resolves `page:`,
-and runs the test.
 
 ![Playwright browser test running from Smartest](/img/playwright-browser-tests.gif)

--- a/documentation/docs/running-test-suites.md
+++ b/documentation/docs/running-test-suites.md
@@ -23,6 +23,15 @@ The init command creates `smartest/test_helper.rb`, `smartest/fixtures/`,
 `smartest/matchers/`, `smartest/matchers/predicate_matcher.rb`, and
 `smartest/example_test.rb`. It does not overwrite existing files.
 
+For a Playwright browser-test scaffold, use:
+
+```bash
+bundle exec smartest --init-browser
+```
+
+That command creates the normal Smartest scaffold plus Playwright fixture,
+matcher, and example files.
+
 Generated tests require the helper by name:
 
 ```ruby
@@ -50,8 +59,8 @@ If no paths are passed, the CLI looks for:
 smartest/**/*_test.rb
 ```
 
-Smartest does not load `test/**/*_test.rb` by default, so a project can keep
-Minitest files under `test/` while using Smartest files under `smartest/`.
+Smartest does not load files from `test/` by default, so a project can keep
+Minitest files there while using Smartest files under `smartest/`.
 
 You can pass a single file:
 

--- a/exe/smartest
+++ b/exe/smartest
@@ -10,6 +10,7 @@ usage = <<~USAGE
     smartest [--profile N] [paths...]
     smartest [--profile N] path/to/test_file.rb:line[-line]
     smartest --init
+    smartest --init-browser
     smartest --version
     smartest --help
 
@@ -36,6 +37,11 @@ begin
     exit Smartest::InitGenerator.new.run
   end
 
+  if ARGV.include?("--init-browser")
+    command = :init_browser
+    exit Smartest::InitBrowserGenerator.new.run
+  end
+
   Smartest.disable_autorun!
   Kernel.prepend Smartest::DSL
   test_load_path = File.expand_path("smartest", Dir.pwd)
@@ -52,7 +58,16 @@ begin
 rescue Exception => error
   raise if Smartest.fatal_exception?(error)
 
-  warn(command == :init ? "Error initializing Smartest:" : "Error loading tests:")
+  warn(
+    case command
+    when :init
+      "Error initializing Smartest:"
+    when :init_browser
+      "Error initializing Smartest browser scaffold:"
+    else
+      "Error loading tests:"
+    end
+  )
   warn "#{error.class}: #{error.message}"
   warn error.backtrace&.first
   exit 1

--- a/lib/smartest.rb
+++ b/lib/smartest.rb
@@ -25,6 +25,7 @@ require_relative "smartest/test_result"
 require_relative "smartest/reporter"
 require_relative "smartest/runner"
 require_relative "smartest/init_generator"
+require_relative "smartest/init_browser_generator"
 require_relative "smartest/cli_arguments"
 
 module Smartest

--- a/lib/smartest/expectation_target.rb
+++ b/lib/smartest/expectation_target.rb
@@ -20,12 +20,22 @@ module Smartest
       if matcher.respond_to?(:does_not_match?)
         return self if matcher.does_not_match?(@actual)
 
-        raise AssertionFailed, matcher.negated_failure_message
+        raise AssertionFailed, negated_failure_message_for(matcher)
       end
 
       return self unless matcher.matches?(@actual)
 
-      raise AssertionFailed, matcher.negated_failure_message
+      raise AssertionFailed, negated_failure_message_for(matcher)
+    end
+
+    private
+
+    def negated_failure_message_for(matcher)
+      return matcher.negated_failure_message if matcher.respond_to?(:negated_failure_message)
+      return matcher.failure_message_when_negated if matcher.respond_to?(:failure_message_when_negated)
+
+      description = matcher.respond_to?(:description) ? matcher.description : matcher.inspect
+      "expected #{@actual.inspect} not to #{description}"
     end
   end
 end

--- a/lib/smartest/init_browser_generator.rb
+++ b/lib/smartest/init_browser_generator.rb
@@ -58,7 +58,7 @@ module Smartest
       end
     RUBY
 
-    EXAMPLE_SPEC = <<~RUBY
+    EXAMPLE_BROWSER_TEST = <<~RUBY
       # frozen_string_literal: true
 
       require "test_helper"
@@ -93,7 +93,7 @@ module Smartest
       update_gemfile
       install_dependencies
       @output.puts
-      @output.puts "Run your browser test suite with: bundle exec smartest smartest/example_spec.rb"
+      @output.puts "Run your browser test suite with: bundle exec smartest smartest/example_browser_test.rb"
 
       0
     end
@@ -101,11 +101,7 @@ module Smartest
     private
 
     def smartest_files
-      Smartest::InitGenerator::FILES.each_with_object({}) do |(path, contents), files|
-        next if path == "smartest/example_test.rb"
-
-        files[path] = contents
-      end.merge("smartest/example_spec.rb" => EXAMPLE_SPEC)
+      Smartest::InitGenerator::FILES.merge("smartest/example_browser_test.rb" => EXAMPLE_BROWSER_TEST)
     end
 
     def create_file(path, contents)

--- a/lib/smartest/init_browser_generator.rb
+++ b/lib/smartest/init_browser_generator.rb
@@ -74,12 +74,6 @@ module Smartest
       end
     RUBY
 
-    INSTALL_COMMANDS = [
-      ["bundle", "install"],
-      ["npm", "install", "playwright", "--save-dev"],
-      ["./node_modules/.bin/playwright", "install"]
-    ].freeze
-
     def initialize(root: Dir.pwd, output: $stdout, command_runner: nil)
       @root = root
       @output = output
@@ -170,12 +164,20 @@ module Smartest
     end
 
     def install_dependencies
-      INSTALL_COMMANDS.each do |command|
+      install_commands.each do |command|
         @output.puts "run     #{command.join(" ")}"
         next if @command_runner.call(command, chdir: @root)
 
         raise "command failed: #{command.join(" ")}"
       end
+    end
+
+    def install_commands
+      commands = [["bundle", "install"]]
+      commands << ["npm", "init", "--yes"] unless File.exist?(File.join(@root, "package.json"))
+      commands << ["npm", "install", "playwright", "--save-dev"]
+      commands << ["./node_modules/.bin/playwright", "install"]
+      commands
     end
 
     def run_system_command(command, chdir:)

--- a/lib/smartest/init_browser_generator.rb
+++ b/lib/smartest/init_browser_generator.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module Smartest
+  class InitBrowserGenerator
+    PLAYWRIGHT_FIXTURE = <<~RUBY
+      # frozen_string_literal: true
+
+      require "playwright"
+
+      class PlaywrightFixture < Smartest::Fixture
+        suite_fixture :playwright do
+          runtime = Playwright.create(
+            playwright_cli_executable_path: "./node_modules/.bin/playwright",
+          )
+          cleanup { runtime.stop }
+          runtime.playwright
+        end
+
+        suite_fixture :browser do |playwright:|
+          browser_type = case ENV["BROWSER"]
+          when "firefox"
+            :firefox
+          when "webkit"
+            :webkit
+          else
+            :chromium
+          end
+
+          launch_options = {}
+          launch_options[:headless] = !%w[0 false].include?(ENV["HEADLESS"])
+          if (slow_mo = ENV["SLOW_MO"].to_i) > 0
+            launch_options[:slowMo] = slow_mo
+          end
+
+          browser = playwright.send(browser_type).launch(**launch_options)
+          cleanup { browser.close }
+          browser
+        end
+
+        fixture :page do |browser:|
+          context = browser.new_context
+          cleanup { context.close }
+          context.new_page
+        end
+      end
+    RUBY
+
+    PLAYWRIGHT_MATCHER = <<~RUBY
+      # frozen_string_literal: true
+
+      require "playwright"
+      require "playwright/test"
+
+      module PlaywrightMatcher
+        include Playwright::Test::Matchers
+      end
+    RUBY
+
+    EXAMPLE_SPEC = <<~RUBY
+      # frozen_string_literal: true
+
+      require "test_helper"
+
+      test("finds the smartest gem on RubyGems") do |page:|
+        page.goto("https://rubygems.org/")
+        page.locator("input[name='query']").fill("smartest")
+        page.keyboard.press("Enter")
+
+        page.locator("a[href='/gems/smartest']").click
+        expect(page).to have_url("https://rubygems.org/gems/smartest")
+        expect(page.locator(".versions")).to have_text("0.3.0.alpha1")
+      end
+    RUBY
+
+    INSTALL_COMMANDS = [
+      ["bundle", "install"],
+      ["npm", "install", "playwright", "--save-dev"],
+      ["./node_modules/.bin/playwright", "install"]
+    ].freeze
+
+    def initialize(root: Dir.pwd, output: $stdout, command_runner: nil)
+      @root = root
+      @output = output
+      @command_runner = command_runner || method(:run_system_command)
+    end
+
+    def run
+      Smartest::InitGenerator.new(
+        root: @root,
+        output: @output,
+        files: smartest_files,
+        final_message: nil
+      ).run
+      create_file("smartest/fixtures/playwright_fixture.rb", PLAYWRIGHT_FIXTURE)
+      create_file("smartest/matchers/playwright_matcher.rb", PLAYWRIGHT_MATCHER)
+      update_test_helper
+      update_gemfile
+      install_dependencies
+      @output.puts
+      @output.puts "Run your browser test suite with: bundle exec smartest smartest/example_spec.rb"
+
+      0
+    end
+
+    private
+
+    def smartest_files
+      Smartest::InitGenerator::FILES.each_with_object({}) do |(path, contents), files|
+        next if path == "smartest/example_test.rb"
+
+        files[path] = contents
+      end.merge("smartest/example_spec.rb" => EXAMPLE_SPEC)
+    end
+
+    def create_file(path, contents)
+      absolute_path = File.join(@root, path)
+
+      if File.exist?(absolute_path)
+        @output.puts "exist   #{path}"
+        return
+      end
+
+      FileUtils.mkdir_p(File.dirname(absolute_path))
+      File.write(absolute_path, contents)
+      @output.puts "create  #{path}"
+    end
+
+    def update_test_helper
+      path = File.join(@root, "smartest/test_helper.rb")
+      contents = File.read(path)
+      updated = ensure_browser_registered(contents)
+
+      return if updated == contents
+
+      File.write(path, updated)
+      @output.puts "update  smartest/test_helper.rb"
+    end
+
+    def ensure_browser_registered(contents)
+      missing_lines = []
+      missing_lines << "  use_fixture PlaywrightFixture\n" unless contents.include?("use_fixture PlaywrightFixture")
+      missing_lines << "  use_matcher PlaywrightMatcher\n" unless contents.include?("use_matcher PlaywrightMatcher")
+      return contents if missing_lines.empty?
+
+      if contents.include?("use_matcher PredicateMatcher")
+        contents.sub(/^(\s*use_matcher PredicateMatcher\n)/) do
+          "#{Regexp.last_match(1)}#{missing_lines.join}"
+        end
+      else
+        "#{contents.chomp}\n\naround_suite do |suite|\n#{missing_lines.join}  suite.run\nend\n"
+      end
+    end
+
+    def update_gemfile
+      path = File.join(@root, "Gemfile")
+      exists = File.exist?(path)
+      contents = exists ? File.read(path) : "source \"https://rubygems.org\"\n"
+
+      if contents.match?(/gem ["']playwright-ruby-client["']/)
+        @output.puts "exist   Gemfile playwright-ruby-client"
+        return
+      end
+
+      separator = contents.end_with?("\n") ? "" : "\n"
+      updated = "#{contents}#{separator}\ngem \"playwright-ruby-client\", group: :test\n"
+      File.write(path, updated)
+      @output.puts(exists ? "update  Gemfile" : "create  Gemfile")
+    end
+
+    def install_dependencies
+      INSTALL_COMMANDS.each do |command|
+        @output.puts "run     #{command.join(" ")}"
+        next if @command_runner.call(command, chdir: @root)
+
+        raise "command failed: #{command.join(" ")}"
+      end
+    end
+
+    def run_system_command(command, chdir:)
+      system(*command, chdir: chdir)
+    end
+  end
+end

--- a/lib/smartest/init_generator.rb
+++ b/lib/smartest/init_generator.rb
@@ -88,19 +88,23 @@ module Smartest
       RUBY
     }.freeze
 
-    def initialize(root: Dir.pwd, output: $stdout)
+    def initialize(root: Dir.pwd, output: $stdout, files: FILES, final_message: "Run your test suite with: bundle exec smartest")
       @root = root
       @output = output
+      @files = files
+      @final_message = final_message
     end
 
     def run
       create_directory("smartest")
       create_directory("smartest/fixtures")
       create_directory("smartest/matchers")
-      FILES.each { |path, contents| create_file(path, contents) }
+      @files.each { |path, contents| create_file(path, contents) }
 
-      @output.puts
-      @output.puts "Run your test suite with: bundle exec smartest"
+      if @final_message
+        @output.puts
+        @output.puts @final_message
+      end
 
       0
     end

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -2044,13 +2044,49 @@ test("cli browser init generator creates Playwright scaffold and installation co
     expect(commands).to eq(
       [
         [["bundle", "install"], dir],
+        [["npm", "init", "--yes"], dir],
         [["npm", "install", "playwright", "--save-dev"], dir],
         [["./node_modules/.bin/playwright", "install"], dir]
       ]
     )
     expect(output.string).to include("run     bundle install")
+    expect(output.string).to include("run     npm init --yes")
     expect(output.string).to include("run     npm install playwright --save-dev")
     expect(output.string).to include("run     ./node_modules/.bin/playwright install")
     expect(output.string).to include("Run your browser test suite with: bundle exec smartest smartest/example_spec.rb")
+  end
+end
+
+test("cli browser init generator skips npm init when package.json already exists") do
+  Dir.mktmpdir do |dir|
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "smartest"
+    RUBY
+    File.write(File.join(dir, "package.json"), "{\n  \"name\": \"existing\"\n}\n")
+
+    commands = []
+    output = StringIO.new
+    generator = Smartest::InitBrowserGenerator.new(
+      root: dir,
+      output: output,
+      command_runner: ->(command, chdir:) {
+        commands << [command, chdir]
+        true
+      }
+    )
+
+    status = generator.run
+
+    expect(status).to eq(0)
+    expect(commands).to eq(
+      [
+        [["bundle", "install"], dir],
+        [["npm", "install", "playwright", "--save-dev"], dir],
+        [["./node_modules/.bin/playwright", "install"], dir]
+      ]
+    )
+    expect(output.string).not_to include("npm init --yes")
   end
 end

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -2024,9 +2024,8 @@ test("cli browser init generator creates Playwright scaffold and installation co
     status = generator.run
 
     expect(status).to eq(0)
-    expect(File.exist?(File.join(dir, "smartest/example_test.rb"))).to eq(false)
-    expect(File.read(File.join(dir, "smartest/example_spec.rb"))).to include("finds the smartest gem on RubyGems")
-    expect(File.read(File.join(dir, "smartest/example_spec.rb"))).to include('expect(page).to have_url("https://rubygems.org/gems/smartest")')
+    expect(File.read(File.join(dir, "smartest/example_browser_test.rb"))).to include("finds the smartest gem on RubyGems")
+    expect(File.read(File.join(dir, "smartest/example_browser_test.rb"))).to include('expect(page).to have_url("https://rubygems.org/gems/smartest")')
     expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include("class PlaywrightFixture < Smartest::Fixture")
     expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include('require "playwright"')
     expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include('playwright_cli_executable_path: "./node_modules/.bin/playwright"')
@@ -2053,7 +2052,7 @@ test("cli browser init generator creates Playwright scaffold and installation co
     expect(output.string).to include("run     npm init --yes")
     expect(output.string).to include("run     npm install playwright --save-dev")
     expect(output.string).to include("run     ./node_modules/.bin/playwright install")
-    expect(output.string).to include("Run your browser test suite with: bundle exec smartest smartest/example_spec.rb")
+    expect(output.string).to include("Run your browser test suite with: bundle exec smartest smartest/example_browser_test.rb")
   end
 end
 

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -268,6 +268,24 @@ test("rejects negated matcher composition") do
   expect(error.message).to eq("not_to does not support matcher composition with .and or .or")
 end
 
+test("not_to supports RSpec-style failure_message_when_negated") do
+  matcher = Class.new do
+    def matches?(_actual)
+      true
+    end
+
+    def failure_message_when_negated
+      "expected negated failure message"
+    end
+  end
+
+  error = SmartestSelfTest.capture_error(Smartest::AssertionFailed) do
+    expect("value").not_to matcher.new
+  end
+
+  expect(error.message).to eq("expected negated failure message")
+end
+
 test("short-circuits or matcher composition") do
   right_matcher = Class.new(Smartest::Matcher) do
     def matches?(_actual)
@@ -1641,6 +1659,7 @@ test("cli prints help") do
   expect(stdout).to include("smartest [--profile N] [paths...]")
   expect(stdout).to include("smartest [--profile N] path/to/test_file.rb:line[-line]")
   expect(stdout).to include("smartest --init")
+  expect(stdout).to include("smartest --init-browser")
   expect(stdout).to include("Use --profile N")
   expect(stdout).to include("smartest/**/*_test.rb")
 end
@@ -1980,5 +1999,58 @@ test("cli init does not overwrite existing scaffold files") do
     expect(File.read(example_path)).to eq("# custom test\n")
     expect(File.read(fixture_path)).to eq("# custom fixture\n")
     expect(File.read(matcher_path)).to eq("# custom matcher\n")
+  end
+end
+
+test("cli browser init generator creates Playwright scaffold and installation commands") do
+  Dir.mktmpdir do |dir|
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "smartest"
+    RUBY
+
+    commands = []
+    output = StringIO.new
+    generator = Smartest::InitBrowserGenerator.new(
+      root: dir,
+      output: output,
+      command_runner: ->(command, chdir:) {
+        commands << [command, chdir]
+        true
+      }
+    )
+
+    status = generator.run
+
+    expect(status).to eq(0)
+    expect(File.exist?(File.join(dir, "smartest/example_test.rb"))).to eq(false)
+    expect(File.read(File.join(dir, "smartest/example_spec.rb"))).to include("finds the smartest gem on RubyGems")
+    expect(File.read(File.join(dir, "smartest/example_spec.rb"))).to include('expect(page).to have_url("https://rubygems.org/gems/smartest")')
+    expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include("class PlaywrightFixture < Smartest::Fixture")
+    expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include('require "playwright"')
+    expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include('playwright_cli_executable_path: "./node_modules/.bin/playwright"')
+    expect(File.read(File.join(dir, "smartest/fixtures/playwright_fixture.rb"))).to include("launch_options[:slowMo] = slow_mo")
+    expect(File.read(File.join(dir, "smartest/matchers/playwright_matcher.rb"))).to include("module PlaywrightMatcher")
+    expect(File.read(File.join(dir, "smartest/matchers/playwright_matcher.rb"))).to include("include Playwright::Test::Matchers")
+
+    helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
+    expect(helper_contents).to include('require "smartest/autorun"')
+    expect(helper_contents).not_to include("smartest-playwright")
+    expect(helper_contents).to include("use_matcher PredicateMatcher\n  use_fixture PlaywrightFixture\n  use_matcher PlaywrightMatcher\n  suite.run")
+
+    gemfile_contents = File.read(File.join(dir, "Gemfile"))
+    expect(gemfile_contents).to include('gem "playwright-ruby-client", group: :test')
+    expect(commands).to eq(
+      [
+        [["bundle", "install"], dir],
+        [["npm", "install", "playwright", "--save-dev"], dir],
+        [["./node_modules/.bin/playwright", "install"], dir]
+      ]
+    )
+    expect(output.string).to include("run     bundle install")
+    expect(output.string).to include("run     npm install playwright --save-dev")
+    expect(output.string).to include("run     ./node_modules/.bin/playwright install")
+    expect(output.string).to include("Run your browser test suite with: bundle exec smartest smartest/example_spec.rb")
   end
 end


### PR DESCRIPTION
## Summary

Adds `bundle exec smartest --init-browser` to generate a Playwright browser-test scaffold from the core `smartest` gem. This replaces the earlier sibling `smartest-playwright` gem approach #29   and keeps Playwright integration as generated project code.

## Details

- Adds `Smartest::InitBrowserGenerator` and wires it into `exe/smartest --init-browser`.
- Generates `smartest/fixtures/playwright_fixture.rb`, `smartest/matchers/playwright_matcher.rb`, and `smartest/example_spec.rb`.
- Registers `PlaywrightFixture` and `PlaywrightMatcher` from the generated helper without requiring a separate extension gem.
- Adds `playwright-ruby-client` to the target Gemfile test group, runs `bundle install`, runs `npm install playwright --save-dev`, and installs Chromium.
- Keeps the generated browser example as `smartest/example_spec.rb`; docs and init output show running it explicitly with `bundle exec smartest smartest/example_spec.rb`.
- Restores the repository to a single-gem setup: one gemspec, normal Bundler gem tasks, and a single RubyGems deploy artifact.
- Updates README, Docusaurus docs, development notes, and changelog for the new behavior.

## Validation

- `bundle install`
- `bundle exec rake test`
- `bundle exec rake build`
- `npm run build` from `documentation/`
