### PR TITLE
Support Ruby 2.7 and newer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "2.7"
+          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ end
 
 ## Installation
 
+Smartest requires Ruby 2.7 or newer.
+
 Add this line to your application's Gemfile:
 
 ```ruby

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -9,7 +9,7 @@ This guide creates a small test scaffold and runs it with Smartest.
 
 ## Requirements
 
-Smartest is a Ruby test runner. The current development version is tested with Ruby 3.3.
+Smartest is a Ruby test runner for Ruby 2.7 and newer.
 
 ## Installation
 

--- a/exe/smartest
+++ b/exe/smartest
@@ -43,7 +43,7 @@ begin
   end
 
   Smartest.disable_autorun!
-  Kernel.prepend Smartest::DSL
+  Smartest.install_dsl!
   test_load_path = File.expand_path("smartest", Dir.pwd)
   $LOAD_PATH.unshift(test_load_path) if Dir.exist?(test_load_path) && !$LOAD_PATH.include?(test_load_path)
 

--- a/lib/smartest.rb
+++ b/lib/smartest.rb
@@ -57,11 +57,26 @@ module Smartest
       end
     end
 
+    def install_dsl!
+      if kernel_prepend_effective?
+        Kernel.prepend DSL
+      else
+        Object.include DSL
+      end
+    end
+
     def fatal_exception?(error)
       error.is_a?(SystemExit) ||
         error.is_a?(Interrupt) ||
         error.is_a?(SignalException) ||
         error.is_a?(NoMemoryError)
+    end
+
+    private
+
+    def kernel_prepend_effective?
+      # Ruby 2.7 does not support Kernel.prepend for defining top-level method.
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0")
     end
   end
 end

--- a/lib/smartest/autorun.rb
+++ b/lib/smartest/autorun.rb
@@ -3,6 +3,6 @@
 require "English"
 require_relative "../smartest"
 
-Kernel.prepend Smartest::DSL
+Smartest.install_dsl!
 
 Smartest.register_autorun!

--- a/smartest.gemspec
+++ b/smartest.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description = "Smartest is a Ruby test runner with pytest-style fixture injection. Tests request fixtures using keyword arguments, fixtures can depend on other fixtures, and cleanup is registered only when needed."
   spec.homepage = "https://smartest-rb.vercel.app"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata = {
     "allowed_push_host" => "https://rubygems.org",


### PR DESCRIPTION
Unfortunately, legacy Ruby on Rails services still use Ruby 2.7.
For upgrading Rails, test is very important, and testing library should support such version.