### PR TITLE
[codex] Add Rails init scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,7 @@ uses `SMARTEST_RAILS_PORT` when it is set, and otherwise asks the OS for an
 available port. The `page` fixture uses a per-test Playwright browser context
 with `baseURL` set to the Rails server URL.
 
-The generated helper wraps each test in
-`Smartest::SimpleStub.with_process_store(Smartest::SimpleStub::SharedStore.new)`
+Smartest automatically gives each test case a process-shared method stub store,
 so method stubs applied in test fixtures can also be seen by the Rails server
 thread.
 
@@ -689,10 +688,11 @@ end
 `use_fixture` is available inside `around_suite` or `around_test` blocks, not as
 a top-level method in a test file.
 
-The stub affects existing instances and new instances of the target class in
-the current Fiber until it is reset. Other Fibers and Threads continue to see
-the original method unless they apply their own stub. Tests can request the
-fixture to make the side effect explicit:
+The stub affects existing instances and new instances of the target class until
+the current fixture scope tears down. During a Smartest test run, method stubs
+are stored in a process-shared store for the current test case, so other Fibers
+and Threads in the same test can see the stub. Tests can request the fixture to
+make the side effect explicit:
 
 ```ruby
 test("checkout succeeds") do |payment_gateway_stub:|
@@ -712,16 +712,16 @@ register `on_teardown { stub.reset }`, and return the stub object.
 `with_stub_const` records the previous constant value, replaces it, yields to
 the block, and restores or removes the constant with `ensure`.
 
-`Smartest::SimpleStub#apply` and `#reset` are idempotent in the current Fiber.
+`Smartest::SimpleStub#apply` and `#reset` are idempotent in the current stub store.
 `apply!` raises
 `Smartest::SimpleStub::AlreadyAppliedError` when the stub is already active in
-the current Fiber, and `reset!` raises
+the current stub store, and `reset!` raises
 `Smartest::SimpleStub::NotAppliedError` when it is not active there. See
 [Stubs](documentation/docs/stubs.md).
 
-Rails browser tests can opt into a process-shared stub store with
-`Smartest::SimpleStub.with_process_store(Smartest::SimpleStub::SharedStore.new)`,
-which lets a same-process Rails server thread see stubs applied by the test.
+If Smartest ever runs tests concurrently in one Ruby process, tests using the
+process-shared method stub store are serialized internally to avoid cross-test
+stub leakage.
 
 ## Logged-in client example
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ To create a Smartest test scaffold:
 For browser tests:
   bundle exec smartest --init-browser
 
+For Rails browser tests:
+  bundle exec smartest --init-rails
+
 See all commands:
   bundle exec smartest --help
 ```
@@ -190,6 +193,7 @@ bundle exec smartest smartest/user_test.rb
 bundle exec smartest smartest/user_test.rb:12
 bundle exec smartest --init
 bundle exec smartest --init-browser
+bundle exec smartest --init-rails
 ```
 
 Output resembles:
@@ -234,6 +238,26 @@ Run the generated browser example with:
 ```bash
 bundle exec smartest smartest/example_browser_test.rb
 ```
+
+## Rails browser quick start
+
+Initialize a Rails browser-test scaffold:
+
+```bash
+bundle exec smartest --init-rails
+```
+
+The Rails init command creates the normal Smartest helper, a Rails system
+fixture, a Playwright matcher, and `smartest/example_rails_system_test.rb`.
+The generated fixture starts `Rails.application` in the test process with Puma,
+uses `SMARTEST_RAILS_PORT` when it is set, and otherwise asks the OS for an
+available port. The `page` fixture uses a per-test Playwright browser context
+with `baseURL` set to the Rails server URL.
+
+The generated helper wraps each test in
+`Smartest::SimpleStub.with_process_store(Smartest::SimpleStub::SharedStore.new)`
+so method stubs applied in test fixtures can also be seen by the Rails server
+thread.
 
 ## Defining tests
 
@@ -694,6 +718,10 @@ the block, and restores or removes the constant with `ensure`.
 the current Fiber, and `reset!` raises
 `Smartest::SimpleStub::NotAppliedError` when it is not active there. See
 [Stubs](documentation/docs/stubs.md).
+
+Rails browser tests can opt into a process-shared stub store with
+`Smartest::SimpleStub.with_process_store(Smartest::SimpleStub::SharedStore.new)`,
+which lets a same-process Rails server thread see stubs applied by the test.
 
 ## Logged-in client example
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ uses `SMARTEST_RAILS_PORT` when it is set, and otherwise asks the OS for an
 available port. The `page` fixture uses a per-test Playwright browser context
 with `baseURL` set to the Rails server URL.
 
-Smartest automatically gives each test case a process-shared method stub store,
+Smartest automatically uses one process-shared method stub store for the suite,
 so method stubs applied in test fixtures can also be seen by the Rails server
 thread.
 
@@ -690,9 +690,9 @@ a top-level method in a test file.
 
 The stub affects existing instances and new instances of the target class until
 the current fixture scope tears down. During a Smartest test run, method stubs
-are stored in a process-shared store for the current test case, so other Fibers
-and Threads in the same test can see the stub. Tests can request the fixture to
-make the side effect explicit:
+are stored in one process-shared store for the suite, so other Fibers and
+Threads in the same Ruby process can see the stub. Tests can request the fixture
+to make the side effect explicit:
 
 ```ruby
 test("checkout succeeds") do |payment_gateway_stub:|
@@ -719,9 +719,8 @@ the current stub store, and `reset!` raises
 `Smartest::SimpleStub::NotAppliedError` when it is not active there. See
 [Stubs](documentation/docs/stubs.md).
 
-If Smartest ever runs tests concurrently in one Ruby process, tests using the
-process-shared method stub store are serialized internally to avoid cross-test
-stub leakage.
+Because method stubs are shared across Threads and Fibers, avoid running tests
+that stub the same method concurrently in the same Ruby process.
 
 ## Logged-in client example
 

--- a/README.md
+++ b/README.md
@@ -712,12 +712,18 @@ register `on_teardown { stub.reset }`, and return the stub object.
 `with_stub_const` records the previous constant value, replaces it, yields to
 the block, and restores or removes the constant with `ensure`.
 
-`Smartest::SimpleStub#apply` and `#reset` are idempotent in the current stub store.
-`apply!` raises
-`Smartest::SimpleStub::AlreadyAppliedError` when the stub is already active in
-the current stub store, and `reset!` raises
-`Smartest::SimpleStub::NotAppliedError` when it is not active there. See
-[Stubs](documentation/docs/stubs.md).
+When the same class and method are stubbed more than once, Smartest keeps those
+stubs in a stack. The newest stub is used while it is active, and resetting it
+restores the previous stub. For example, a test-scoped
+`ApplicationController#current_user` stub can override a suite-scoped
+`current_user` stub without removing the suite-scoped stub.
+
+`Smartest::SimpleStub#apply` is idempotent for the same stub object, and
+`#reset` is safe to call after that object's stub has already been removed.
+`apply!` raises `Smartest::SimpleStub::AlreadyAppliedError` when that stub object
+is already active, and `reset!` raises
+`Smartest::SimpleStub::NotAppliedError` when there is no active stub entry that
+the object can reset. See [Stubs](documentation/docs/stubs.md).
 
 Because method stubs are shared across Threads and Fibers, avoid running tests
 that stub the same method concurrently in the same Ruby process.

--- a/SMARTEST_DESIGN.md
+++ b/SMARTEST_DESIGN.md
@@ -869,6 +869,9 @@ To create a Smartest test scaffold:
 For browser tests:
   bundle exec smartest --init-browser
 
+For Rails browser tests:
+  bundle exec smartest --init-rails
+
 See all commands:
   bundle exec smartest --help
 ```

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -67,22 +67,15 @@ an available port by binding Puma to port `0`.
 ## Shared Method Stubs
 
 Rails browser tests often need stubs applied in fixture setup to affect code
-that runs inside the Rails server thread. The generated helper wraps every test
-with a process-shared `SimpleStub` store:
+that runs inside the Rails server thread. Smartest automatically gives each test
+case a process-shared `SimpleStub` store. That makes method stubs installed by
+fixtures visible to the same-process Rails server thread without adding any
+store setup to `smartest/test_helper.rb`.
 
-```ruby
-around_test do |test|
-  store = Smartest::SimpleStub::SharedStore.new
-
-  Smartest::SimpleStub.with_process_store(store) do
-    test.run
-  end
-end
-```
-
-That makes method stubs installed by fixtures visible to the same-process Rails
-server thread. Keep these tests sequential inside one Ruby process; concurrent
-tests using a process-shared stub store can overwrite each other's stubs.
+If Smartest runs tests concurrently in one Ruby process in the future, tests
+using this process-shared method stub store are serialized internally while the
+test store is active. This avoids one test's Rails server thread reading another
+test's stubs.
 
 ## Example
 

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -67,15 +67,13 @@ an available port by binding Puma to port `0`.
 ## Shared Method Stubs
 
 Rails browser tests often need stubs applied in fixture setup to affect code
-that runs inside the Rails server thread. Smartest automatically gives each test
-case a process-shared `SimpleStub` store. That makes method stubs installed by
-fixtures visible to the same-process Rails server thread without adding any
-store setup to `smartest/test_helper.rb`.
+that runs inside the Rails server thread. Smartest automatically uses one
+process-shared `SimpleStub` store for the suite. That makes method stubs
+installed by fixtures visible to the same-process Rails server thread without
+adding any store setup to `smartest/test_helper.rb`.
 
-If Smartest runs tests concurrently in one Ruby process in the future, tests
-using this process-shared method stub store are serialized internally while the
-test store is active. This avoids one test's Rails server thread reading another
-test's stubs.
+Because method stubs are shared across Threads and Fibers, avoid running tests
+that stub the same method concurrently in the same Ruby process.
 
 ## Example
 

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -1,0 +1,110 @@
+---
+title: Rails Browser Tests
+description: Start a same-process Rails test server and drive it with Playwright fixtures.
+---
+
+# Rails Browser Tests
+
+Smartest can scaffold a small Rails browser-test setup:
+
+```bash
+bundle exec smartest --init-rails
+```
+
+The generated scaffold creates:
+
+```text
+smartest/fixtures/rails_system_fixture.rb
+smartest/matchers/playwright_matcher.rb
+smartest/example_rails_system_test.rb
+```
+
+It also adds `playwright-ruby-client` to the Gemfile test group, installs the
+Playwright npm package, and downloads browsers.
+
+## Fixture Structure
+
+The generated Rails fixture keeps these resources suite-scoped:
+
+- `rails_server`
+- `base_url`
+- `playwright`
+- `browser`
+
+Each test gets its own browser context and page:
+
+```ruby
+class RailsSystemFixture < Smartest::Fixture
+  fixture :browser_context do |base_url:, browser:|
+    context = browser.new_context(baseURL: base_url)
+    on_teardown { context.close }
+    context
+  end
+
+  fixture :page do |browser_context:|
+    page = browser_context.new_page
+    on_teardown { page.close }
+    page
+  end
+end
+```
+
+The `rails_server` fixture sets `RAILS_ENV` and `RACK_ENV` to `test` when they
+are not already set, requires `config/environment`, and starts
+`Rails.application` with Puma in the same Ruby process as the test runner.
+
+## Port Selection
+
+Set `SMARTEST_RAILS_PORT` when you need a fixed Rails test server port:
+
+```bash
+SMARTEST_RAILS_PORT=4001 bundle exec smartest smartest/example_rails_system_test.rb
+```
+
+When the environment variable is not set, the generated server asks the OS for
+an available port by binding Puma to port `0`.
+
+## Shared Method Stubs
+
+Rails browser tests often need stubs applied in fixture setup to affect code
+that runs inside the Rails server thread. The generated helper wraps every test
+with a process-shared `SimpleStub` store:
+
+```ruby
+around_test do |test|
+  store = Smartest::SimpleStub::SharedStore.new
+
+  Smartest::SimpleStub.with_process_store(store) do
+    test.run
+  end
+end
+```
+
+That makes method stubs installed by fixtures visible to the same-process Rails
+server thread. Keep these tests sequential inside one Ruby process; concurrent
+tests using a process-shared stub store can overwrite each other's stubs.
+
+## Example
+
+```ruby
+class EdgeCaseFixture < Smartest::Fixture
+  fixture :suspended_user do
+    create(:user, :suspended)
+  end
+
+  fixture :suspended_user_page do |page:, suspended_user:|
+    simple_stub_any_instance_of(ApplicationController, :current_user) { suspended_user }
+    page
+  end
+end
+```
+
+```ruby
+test("suspended user sees account restriction page") do |suspended_user_page:|
+  suspended_user_page.goto("/dashboard")
+
+  expect(
+    suspended_user_page.get_by_role("heading", name: "Your account is suspended")
+  ).to be_visible
+end
+```

--- a/documentation/docs/reference/errors.md
+++ b/documentation/docs/reference/errors.md
@@ -19,7 +19,7 @@ expected 2 to eq 3
 ## `Smartest::SimpleStub::AlreadyAppliedError`
 
 Raised when `Smartest::SimpleStub#apply!` is called for a stub that is already
-active in the current Fiber:
+active in the current stub store:
 
 ```text
 stub for PaymentGateway#charge is already applied
@@ -30,7 +30,7 @@ Use `apply` instead of `apply!` when repeated application should be ignored.
 ## `Smartest::SimpleStub::NotAppliedError`
 
 Raised when `Smartest::SimpleStub#reset!` is called for a stub that is not
-active in the current Fiber:
+active in the current stub store:
 
 ```text
 stub for PaymentGateway#charge is not applied

--- a/documentation/docs/reference/errors.md
+++ b/documentation/docs/reference/errors.md
@@ -18,19 +18,22 @@ expected 2 to eq 3
 
 ## `Smartest::SimpleStub::AlreadyAppliedError`
 
-Raised when `Smartest::SimpleStub#apply!` is called for a stub that is already
-active in the current stub store:
+Raised when `Smartest::SimpleStub#apply!` is called on a stub object that is
+already active:
 
 ```text
 stub for PaymentGateway#charge is already applied
 ```
 
-Use `apply` instead of `apply!` when repeated application should be ignored.
+Use `apply` instead of `apply!` when repeated application of the same stub object
+should be ignored. Separate stub objects for the same class and method are
+stacked; the newest stub handles calls until it is reset.
 
 ## `Smartest::SimpleStub::NotAppliedError`
 
-Raised when `Smartest::SimpleStub#reset!` is called for a stub that is not
-active in the current stub store:
+Raised when `Smartest::SimpleStub#reset!` cannot find an active stub entry to
+reset. This happens when the stub object was already removed, or when no stub is
+active for the target class and method:
 
 ```text
 stub for PaymentGateway#charge is not applied

--- a/documentation/docs/running-test-suites.md
+++ b/documentation/docs/running-test-suites.md
@@ -32,6 +32,17 @@ bundle exec smartest --init-browser
 That command creates the normal Smartest scaffold plus Playwright fixture,
 matcher, and example files.
 
+For a Rails browser-test scaffold, use:
+
+```bash
+bundle exec smartest --init-rails
+```
+
+That command creates the normal Smartest scaffold plus a Rails system fixture,
+Playwright matcher, and Rails browser example. The generated Rails server uses
+`SMARTEST_RAILS_PORT` when set and otherwise binds to an OS-assigned available
+port.
+
 Generated tests require the helper by name:
 
 ```ruby
@@ -73,6 +84,9 @@ To create a Smartest test scaffold:
 
 For browser tests:
   bundle exec smartest --init-browser
+
+For Rails browser tests:
+  bundle exec smartest --init-rails
 
 See all commands:
   bundle exec smartest --help
@@ -151,6 +165,9 @@ Common commands:
 
   bundle exec smartest --init-browser
       Generate a Playwright browser-test scaffold
+
+  bundle exec smartest --init-rails
+      Generate a Rails browser-test scaffold
 ```
 
 Show the installed Smartest version:

--- a/documentation/docs/stubs.md
+++ b/documentation/docs/stubs.md
@@ -61,8 +61,9 @@ simple_stub_any_instance_of(PaymentGateway, :charge) { :approved }
 ```
 
 The stub affects existing instances and new instances of the target class in
-the current Fiber until teardown resets it. Other Fibers and Threads continue to
-see the original method unless they apply their own stub.
+the current fixture scope until teardown resets it. During a Smartest test run,
+method stubs use a process-shared store for the current test case, so other
+Fibers and Threads in the same test can see the stub.
 
 A Rails authentication fixture might look like this:
 
@@ -264,13 +265,14 @@ stub = Smartest::SimpleStub.new(Time.singleton_class, :now) { fixed_time }
 repeated application or reset should fail.
 
 `apply!` raises `Smartest::SimpleStub::AlreadyAppliedError` when the stub is
-already active in the current Fiber. `reset!` raises
+already active in the current stub store. `reset!` raises
 `Smartest::SimpleStub::NotAppliedError` when the stub is not active in the
-current Fiber.
+current stub store.
 
-`Smartest::SimpleStub` stores the active stub in Fiber-local storage keyed by
-the target class and method name. That means setup and teardown can use separate
-stub instances in the same Fiber:
+During a Smartest run, the runner creates a suite-level process-shared store and
+a test-level process-shared store. `around_suite` stubs and `suite_fixture`
+stubs are stored in the suite store. Test-scoped fixture and test body stubs are
+stored in the current test store and reset by fixture teardown:
 
 ```ruby
 Smartest::SimpleStub.new(User, :name) { "Test User" }.apply
@@ -279,27 +281,15 @@ Smartest::SimpleStub.new(User, :name) { "Test User" }.apply
 Smartest::SimpleStub.new(User, :name).reset
 ```
 
-For same-process Rails browser tests, use a process-shared store around the test
-when a Rails server thread must see stubs applied by fixture setup:
-
-```ruby
-around_test do |test|
-  store = Smartest::SimpleStub::SharedStore.new
-
-  Smartest::SimpleStub.with_process_store(store) do
-    test.run
-  end
-end
-```
-
-`with_process_store` restores the previous store and clears the shared store
-when the block exits.
+Outside a Smartest runner, direct low-level use falls back to `FiberLocalStore`
+so standalone setup and teardown can still be scoped to the current Fiber.
 
 ## Scope and Concurrency
 
 `Smartest::SimpleStub` installs a process-wide dispatcher method, but the active
-stub implementation is looked up from `FiberLocalStore` by default. Applying a
-stub in one Fiber does not change behavior in another Fiber or Thread:
+stub implementation is looked up from the current Smartest stub store. In normal
+Smartest tests, applying a stub in one Fiber or Thread changes behavior in other
+Fibers and Threads that run inside the same test case:
 
 ```ruby
 stub = Smartest::SimpleStub.new(User, :name) { "Stubbed" }
@@ -310,20 +300,16 @@ User.new.name
 
 Fiber.new do
   User.new.name
-  # Calls the original method.
+  # => "Stubbed"
 end.resume
 
 stub.reset!
 ```
 
-Different Threads can apply different stubs for the same class and method at
-the same time. Teardown still matters, so prefer the fixture helpers when the
-stub belongs to test setup.
-
-When `with_process_store` is active, all Threads in the process read and write
-the same `SharedStore`. That mode is intended for same-process Rails server
-tests. Do not run tests that use a process-shared stub store concurrently in the
-same Ruby process.
+If Smartest runs tests concurrently in one Ruby process in the future, tests
+using the process-shared method stub store are serialized internally while their
+test store is active. This avoids one test's Rails server thread reading another
+test's stubs.
 
 Constant stubs are different: Ruby constant lookup does not provide a Fiber-local
 hook, so `with_stub_const` replaces the constant on the owner module. That

--- a/documentation/docs/stubs.md
+++ b/documentation/docs/stubs.md
@@ -62,8 +62,8 @@ simple_stub_any_instance_of(PaymentGateway, :charge) { :approved }
 
 The stub affects existing instances and new instances of the target class in
 the current fixture scope until teardown resets it. During a Smartest test run,
-method stubs use a process-shared store for the current test case, so other
-Fibers and Threads in the same test can see the stub.
+method stubs use one process-shared store for the suite, so other Fibers and
+Threads in the same Ruby process can see the stub.
 
 A Rails authentication fixture might look like this:
 
@@ -269,10 +269,10 @@ already active in the current stub store. `reset!` raises
 `Smartest::SimpleStub::NotAppliedError` when the stub is not active in the
 current stub store.
 
-During a Smartest run, the runner creates a suite-level process-shared store and
-a test-level process-shared store. `around_suite` stubs and `suite_fixture`
-stubs are stored in the suite store. Test-scoped fixture and test body stubs are
-stored in the current test store and reset by fixture teardown:
+During a Smartest run, the runner creates one process-shared store for the
+suite. `around_suite`, `suite_fixture`, test-scoped fixture, and test body stubs
+are stored in that same suite store. Fixture helper stubs are still reset by
+fixture teardown:
 
 ```ruby
 Smartest::SimpleStub.new(User, :name) { "Test User" }.apply
@@ -281,15 +281,16 @@ Smartest::SimpleStub.new(User, :name) { "Test User" }.apply
 Smartest::SimpleStub.new(User, :name).reset
 ```
 
-Outside a Smartest runner, direct low-level use falls back to `FiberLocalStore`
-so standalone setup and teardown can still be scoped to the current Fiber.
+Outside a Smartest runner, direct low-level use falls back to a process-local
+default store so standalone setup and teardown can still work without runner
+state.
 
 ## Scope and Concurrency
 
 `Smartest::SimpleStub` installs a process-wide dispatcher method, but the active
-stub implementation is looked up from the current Smartest stub store. In normal
+stub implementation is looked up from the current Smartest stub store. In
 Smartest tests, applying a stub in one Fiber or Thread changes behavior in other
-Fibers and Threads that run inside the same test case:
+Fibers and Threads in the same Ruby process.
 
 ```ruby
 stub = Smartest::SimpleStub.new(User, :name) { "Stubbed" }
@@ -298,20 +299,13 @@ stub.apply!
 User.new.name
 # => "Stubbed"
 
-Fiber.new do
-  User.new.name
-  # => "Stubbed"
-end.resume
-
 stub.reset!
 ```
 
-If Smartest runs tests concurrently in one Ruby process in the future, tests
-using the process-shared method stub store are serialized internally while their
-test store is active. This avoids one test's Rails server thread reading another
-test's stubs.
+Because method stubs are shared across Threads and Fibers, avoid running tests
+that stub the same method concurrently in the same Ruby process.
 
-Constant stubs are different: Ruby constant lookup does not provide a Fiber-local
-hook, so `with_stub_const` replaces the constant on the owner module. That
-change is process-global until teardown runs. Avoid concurrent tests that stub
-the same constant.
+Constant stubs are different: Ruby constant lookup does not provide a method
+dispatch hook, so `with_stub_const` replaces the constant on the owner module.
+That change is process-global until teardown runs. Avoid concurrent tests that
+stub the same constant.

--- a/documentation/docs/stubs.md
+++ b/documentation/docs/stubs.md
@@ -279,11 +279,27 @@ Smartest::SimpleStub.new(User, :name) { "Test User" }.apply
 Smartest::SimpleStub.new(User, :name).reset
 ```
 
+For same-process Rails browser tests, use a process-shared store around the test
+when a Rails server thread must see stubs applied by fixture setup:
+
+```ruby
+around_test do |test|
+  store = Smartest::SimpleStub::SharedStore.new
+
+  Smartest::SimpleStub.with_process_store(store) do
+    test.run
+  end
+end
+```
+
+`with_process_store` restores the previous store and clears the shared store
+when the block exits.
+
 ## Scope and Concurrency
 
 `Smartest::SimpleStub` installs a process-wide dispatcher method, but the active
-stub implementation is looked up from Fiber-local storage. Applying a stub in
-one Fiber does not change behavior in another Fiber or Thread:
+stub implementation is looked up from `FiberLocalStore` by default. Applying a
+stub in one Fiber does not change behavior in another Fiber or Thread:
 
 ```ruby
 stub = Smartest::SimpleStub.new(User, :name) { "Stubbed" }
@@ -303,6 +319,11 @@ stub.reset!
 Different Threads can apply different stubs for the same class and method at
 the same time. Teardown still matters, so prefer the fixture helpers when the
 stub belongs to test setup.
+
+When `with_process_store` is active, all Threads in the process read and write
+the same `SharedStore`. That mode is intended for same-process Rails server
+tests. Do not run tests that use a process-shared stub store concurrently in the
+same Ruby process.
 
 Constant stubs are different: Ruby constant lookup does not provide a Fiber-local
 hook, so `with_stub_const` replaces the constant on the owner module. That

--- a/documentation/docs/stubs.md
+++ b/documentation/docs/stubs.md
@@ -166,6 +166,12 @@ Teardown is tied to the fixture lifecycle:
 - `fixture` method stubs reset after each test.
 - `suite_fixture` method stubs reset after the suite fixture scope ends.
 
+When the same class and method are stubbed more than once, Smartest keeps those
+stubs in a stack. The newest stub is used while it is active, and resetting it
+restores the previous stub. For example, a test-scoped
+`ApplicationController#current_user` stub can override a suite-scoped
+`current_user` stub without removing the suite-scoped stub.
+
 In most cases, prefer the fixture helpers so stub lifetime is automatically tied
 to the fixture lifecycle.
 
@@ -261,13 +267,19 @@ The first argument must be a `Class`, and the second argument must be a
 stub = Smartest::SimpleStub.new(Time.singleton_class, :now) { fixed_time }
 ```
 
-`apply` and `reset` are safe to call more than once. Use the bang methods when
-repeated application or reset should fail.
+`apply` is safe to call more than once on the same stub object. `reset` is safe
+to call more than once after that object's stub has been removed. Use the bang
+methods when repeated application or reset should fail.
 
-`apply!` raises `Smartest::SimpleStub::AlreadyAppliedError` when the stub is
-already active in the current stub store. `reset!` raises
-`Smartest::SimpleStub::NotAppliedError` when the stub is not active in the
-current stub store.
+`apply!` raises `Smartest::SimpleStub::AlreadyAppliedError` when that
+`Smartest::SimpleStub` object is already active. `reset!` raises
+`Smartest::SimpleStub::NotAppliedError` when there is no active stub entry that
+the object can reset. A fresh `Smartest::SimpleStub` object with no applied entry
+can still reset the newest active stub for the same class and method.
+
+Separate `Smartest::SimpleStub` objects for the same class and method are
+stacked. The newest stub handles calls, and resetting it restores the previous
+stub.
 
 During a Smartest run, the runner creates one process-shared store for the
 suite. `around_suite`, `suite_fixture`, test-scoped fixture, and test body stubs

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -13,6 +13,7 @@ const sidebars = {
     'matchers',
     'helpers',
     'playwright-browser-tests',
+    'rails-browser-tests',
     {
       type: 'category',
       label: 'Comparisons',

--- a/exe/smartest
+++ b/exe/smartest
@@ -28,6 +28,9 @@ usage = <<~USAGE
     bundle exec smartest --init-browser
         Generate a Playwright browser-test scaffold
 
+    bundle exec smartest --init-rails
+        Generate a Rails browser-test scaffold
+
   Options:
     --profile N
         Print the N slowest tests. Defaults to 5.
@@ -47,6 +50,9 @@ missing_smartest_directory_message = <<~MESSAGE
 
   For browser tests:
     bundle exec smartest --init-browser
+
+  For Rails browser tests:
+    bundle exec smartest --init-rails
 
   See all commands:
     bundle exec smartest --help
@@ -73,6 +79,11 @@ begin
   if ARGV.include?("--init-browser")
     command = :init_browser
     exit Smartest::InitBrowserGenerator.new.run
+  end
+
+  if ARGV.include?("--init-rails")
+    command = :init_rails
+    exit Smartest::InitRailsGenerator.new.run
   end
 
   Smartest.disable_autorun!
@@ -103,6 +114,8 @@ rescue Exception => error
       "Error initializing Smartest:"
     when :init_browser
       "Error initializing Smartest browser scaffold:"
+    when :init_rails
+      "Error initializing Smartest Rails scaffold:"
     else
       "Error loading tests:"
     end

--- a/lib/smartest.rb
+++ b/lib/smartest.rb
@@ -28,6 +28,7 @@ require_relative "smartest/reporter"
 require_relative "smartest/runner"
 require_relative "smartest/init_generator"
 require_relative "smartest/init_browser_generator"
+require_relative "smartest/init_rails_generator"
 require_relative "smartest/cli_arguments"
 
 module Smartest

--- a/lib/smartest/fixture_set.rb
+++ b/lib/smartest/fixture_set.rb
@@ -2,11 +2,12 @@
 
 module Smartest
   class FixtureSet
-    def initialize(fixture_classes, context:, scope: :test, parent: nil)
+    def initialize(fixture_classes, context:, scope: :test, parent: nil, stub_store: nil)
       @fixture_classes = fixture_classes.to_a
       @context = context
       @scope = normalize_scope(scope)
       @parent = parent
+      @stub_store = stub_store
       @cache = {}
       @setup_errors = {}
       @teardowns = []
@@ -39,7 +40,7 @@ module Smartest
 
       @resolving << symbol_name
       dependencies = resolve_keywords(definition.dependencies)
-      @cache[symbol_name] = @instances[symbol_name].instance_exec(**dependencies, &definition.block)
+      @cache[symbol_name] = resolve_fixture_value(symbol_name, dependencies, definition)
     rescue Exception => error
       raise if Smartest.fatal_exception?(error)
 
@@ -47,6 +48,14 @@ module Smartest
       raise
     ensure
       @resolving.pop if @resolving.last == symbol_name
+    end
+
+    def resolve_fixture_value(name, dependencies, definition)
+      return @instances[name].instance_exec(**dependencies, &definition.block) unless @stub_store && @scope == :suite
+
+      Smartest::SimpleStub.with_process_store(@stub_store, serialize: false, clear: false) do
+        @instances[name].instance_exec(**dependencies, &definition.block)
+      end
     end
 
     def add_teardown(&block)

--- a/lib/smartest/fixture_set.rb
+++ b/lib/smartest/fixture_set.rb
@@ -2,12 +2,11 @@
 
 module Smartest
   class FixtureSet
-    def initialize(fixture_classes, context:, scope: :test, parent: nil, stub_store: nil)
+    def initialize(fixture_classes, context:, scope: :test, parent: nil)
       @fixture_classes = fixture_classes.to_a
       @context = context
       @scope = normalize_scope(scope)
       @parent = parent
-      @stub_store = stub_store
       @cache = {}
       @setup_errors = {}
       @teardowns = []
@@ -40,7 +39,7 @@ module Smartest
 
       @resolving << symbol_name
       dependencies = resolve_keywords(definition.dependencies)
-      @cache[symbol_name] = resolve_fixture_value(symbol_name, dependencies, definition)
+      @cache[symbol_name] = @instances[symbol_name].instance_exec(**dependencies, &definition.block)
     rescue Exception => error
       raise if Smartest.fatal_exception?(error)
 
@@ -48,14 +47,6 @@ module Smartest
       raise
     ensure
       @resolving.pop if @resolving.last == symbol_name
-    end
-
-    def resolve_fixture_value(name, dependencies, definition)
-      return @instances[name].instance_exec(**dependencies, &definition.block) unless @stub_store && @scope == :suite
-
-      Smartest::SimpleStub.with_process_store(@stub_store, serialize: false, clear: false) do
-        @instances[name].instance_exec(**dependencies, &definition.block)
-      end
     end
 
     def add_teardown(&block)

--- a/lib/smartest/init_rails_generator.rb
+++ b/lib/smartest/init_rails_generator.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module Smartest
+  class InitRailsGenerator
+    RAILS_SYSTEM_FIXTURE = <<~RUBY
+      # frozen_string_literal: true
+
+      require "net/http"
+      require "playwright"
+      require "puma"
+      require "timeout"
+
+      class SmartestRailsTestServer
+        DEFAULT_HOST = "127.0.0.1"
+        DEFAULT_READY_TIMEOUT = 10
+
+        attr_reader :host, :port
+
+        def initialize(app:, host: DEFAULT_HOST, port: nil)
+          @app = app
+          @host = host
+          @requested_port = port || ENV["SMARTEST_RAILS_PORT"]&.to_i || 0
+          @server = Puma::Server.new(@app)
+          listener = @server.add_tcp_listener(@host, @requested_port)
+          @port = listener.addr[1]
+          @thread = nil
+        end
+
+        def start
+          @thread ||= @server.run
+        end
+
+        def stop
+          @server.stop(true)
+        end
+
+        def wait_for_ready(timeout: DEFAULT_READY_TIMEOUT)
+          Timeout.timeout(timeout) do
+            sleep 0.05 until responsive?
+          end
+        rescue Timeout::Error
+          raise "Rails test server did not become ready at \#{base_url} within \#{timeout} seconds"
+        end
+
+        def wait_for_stopped(timeout: DEFAULT_READY_TIMEOUT)
+          return unless @thread
+          return if @thread.join(timeout)
+
+          raise "Rails test server did not stop within \#{timeout} seconds"
+        end
+
+        def base_url
+          "http://\#{host}:\#{port}"
+        end
+
+        private
+
+        def responsive?
+          Net::HTTP.start(host, port, open_timeout: 0.2, read_timeout: 0.2) do |http|
+            http.head("/")
+          end
+          true
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, IOError, SocketError, SystemCallError
+          false
+        end
+      end
+
+      class RailsSystemFixture < Smartest::Fixture
+        suite_fixture :rails_server do
+          ENV["RAILS_ENV"] ||= "test"
+          ENV["RACK_ENV"] ||= ENV["RAILS_ENV"]
+          require File.expand_path("../../config/environment", __dir__)
+
+          server = SmartestRailsTestServer.new(app: Rails.application)
+          server.start
+          server.wait_for_ready
+
+          on_teardown do
+            server.stop
+            server.wait_for_stopped
+          end
+
+          server
+        end
+
+        suite_fixture :base_url do |rails_server:|
+          rails_server.base_url
+        end
+
+        suite_fixture :playwright do
+          runtime = Playwright.create(
+            playwright_cli_executable_path: "./node_modules/.bin/playwright",
+          )
+          on_teardown { runtime.stop }
+          runtime.playwright
+        end
+
+        suite_fixture :browser do |playwright:|
+          browser_type = case ENV["BROWSER"]
+          when "firefox"
+            :firefox
+          when "webkit"
+            :webkit
+          else
+            :chromium
+          end
+
+          launch_options = {}
+          launch_options[:headless] = !%w[0 false].include?(ENV["HEADLESS"])
+          if (slow_mo = ENV["SLOW_MO"].to_i) > 0
+            launch_options[:slowMo] = slow_mo
+          end
+
+          browser = playwright.send(browser_type).launch(**launch_options)
+          on_teardown { browser.close }
+          browser
+        end
+
+        fixture :browser_context do |base_url:, browser:|
+          context = browser.new_context(baseURL: base_url)
+          on_teardown { context.close }
+          context
+        end
+
+        fixture :page do |browser_context:|
+          page = browser_context.new_page
+          on_teardown { page.close }
+          page
+        end
+      end
+    RUBY
+
+    PLAYWRIGHT_MATCHER = <<~RUBY
+      # frozen_string_literal: true
+
+      require "playwright"
+      require "playwright/test"
+
+      module PlaywrightMatcher
+        include Playwright::Test::Matchers
+      end
+    RUBY
+
+    EXAMPLE_RAILS_SYSTEM_TEST = <<~RUBY
+      # frozen_string_literal: true
+
+      require "test_helper"
+
+      test("loads the Rails application") do |page:|
+        response = page.goto("/")
+
+        expect(response.status).to be_between(200, 599)
+      end
+    RUBY
+
+    def initialize(root: Dir.pwd, output: $stdout, command_runner: nil)
+      @root = root
+      @output = output
+      @command_runner = command_runner || method(:run_system_command)
+    end
+
+    def run
+      Smartest::InitGenerator.new(
+        root: @root,
+        output: @output,
+        files: smartest_files,
+        final_message: nil
+      ).run
+      create_file("smartest/fixtures/rails_system_fixture.rb", RAILS_SYSTEM_FIXTURE)
+      create_file("smartest/matchers/playwright_matcher.rb", PLAYWRIGHT_MATCHER)
+      update_test_helper
+      update_gemfile
+      install_dependencies
+      @output.puts
+      @output.puts "Run your Rails browser test suite with: bundle exec smartest smartest/example_rails_system_test.rb"
+
+      0
+    end
+
+    private
+
+    def smartest_files
+      Smartest::InitGenerator::FILES.merge("smartest/example_rails_system_test.rb" => EXAMPLE_RAILS_SYSTEM_TEST)
+    end
+
+    def create_file(path, contents)
+      absolute_path = File.join(@root, path)
+
+      if File.exist?(absolute_path)
+        @output.puts "exist   #{path}"
+        return
+      end
+
+      FileUtils.mkdir_p(File.dirname(absolute_path))
+      File.write(absolute_path, contents)
+      @output.puts "create  #{path}"
+    end
+
+    def update_test_helper
+      path = File.join(@root, "smartest/test_helper.rb")
+      contents = File.read(path)
+      updated = ensure_rails_registered(contents)
+      updated = ensure_shared_stub_store(updated)
+
+      return if updated == contents
+
+      File.write(path, updated)
+      @output.puts "update  smartest/test_helper.rb"
+    end
+
+    def ensure_rails_registered(contents)
+      missing_lines = []
+      missing_lines << "  use_fixture RailsSystemFixture\n" unless contents.include?("use_fixture RailsSystemFixture")
+      missing_lines << "  use_matcher PlaywrightMatcher\n" unless contents.include?("use_matcher PlaywrightMatcher")
+      return contents if missing_lines.empty?
+
+      if contents.include?("use_matcher PredicateMatcher")
+        contents.sub(/^(\s*use_matcher PredicateMatcher\n)/) do
+          "#{Regexp.last_match(1)}#{missing_lines.join}"
+        end
+      else
+        "#{contents.chomp}\n\naround_suite do |suite|\n#{missing_lines.join}  suite.run\nend\n"
+      end
+    end
+
+    def ensure_shared_stub_store(contents)
+      return contents if contents.include?("Smartest::SimpleStub.with_process_store")
+
+      <<~RUBY
+        #{contents.chomp}
+
+        around_test do |test|
+          store = Smartest::SimpleStub::SharedStore.new
+
+          Smartest::SimpleStub.with_process_store(store) do
+            test.run
+          end
+        end
+      RUBY
+    end
+
+    def update_gemfile
+      path = File.join(@root, "Gemfile")
+      exists = File.exist?(path)
+      contents = exists ? File.read(path) : "source \"https://rubygems.org\"\n"
+
+      if contents.match?(/gem ["']playwright-ruby-client["']/)
+        @output.puts "exist   Gemfile playwright-ruby-client"
+        return
+      end
+
+      separator = contents.end_with?("\n") ? "" : "\n"
+      updated = "#{contents}#{separator}\ngem \"playwright-ruby-client\", group: :test\n"
+      File.write(path, updated)
+      @output.puts(exists ? "update  Gemfile" : "create  Gemfile")
+    end
+
+    def install_dependencies
+      install_commands.each do |command|
+        @output.puts "run     #{command.join(" ")}"
+        next if @command_runner.call(command, chdir: @root)
+
+        raise "command failed: #{command.join(" ")}"
+      end
+    end
+
+    def install_commands
+      commands = [["bundle", "install"]]
+      commands << ["npm", "init", "--yes"] unless File.exist?(File.join(@root, "package.json"))
+      commands << ["npm", "install", "playwright", "--save-dev"]
+      commands << ["./node_modules/.bin/playwright", "install"]
+      commands
+    end
+
+    def run_system_command(command, chdir:)
+      system(*command, chdir: chdir)
+    end
+  end
+end

--- a/lib/smartest/init_rails_generator.rb
+++ b/lib/smartest/init_rails_generator.rb
@@ -202,7 +202,6 @@ module Smartest
       path = File.join(@root, "smartest/test_helper.rb")
       contents = File.read(path)
       updated = ensure_rails_registered(contents)
-      updated = ensure_shared_stub_store(updated)
 
       return if updated == contents
 
@@ -223,22 +222,6 @@ module Smartest
       else
         "#{contents.chomp}\n\naround_suite do |suite|\n#{missing_lines.join}  suite.run\nend\n"
       end
-    end
-
-    def ensure_shared_stub_store(contents)
-      return contents if contents.include?("Smartest::SimpleStub.with_process_store")
-
-      <<~RUBY
-        #{contents.chomp}
-
-        around_test do |test|
-          store = Smartest::SimpleStub::SharedStore.new
-
-          Smartest::SimpleStub.with_process_store(store) do
-            test.run
-          end
-        end
-      RUBY
     end
 
     def update_gemfile

--- a/lib/smartest/runner.rb
+++ b/lib/smartest/runner.rb
@@ -13,12 +13,12 @@ module Smartest
       suite_teardown_errors = []
       suite_errors = []
       @suite_fixture_set = nil
-      @simple_stub_suite_store = Smartest::SimpleStub::SharedStore.new
+      simple_stub_store = Smartest::SimpleStub::LocalStore.new
 
       @reporter.start(@tests.count)
 
       begin
-        Smartest::SimpleStub.with_process_store(@simple_stub_suite_store, serialize: false) do
+        Smartest::SimpleStub.with_store(simple_stub_store) do
           run_around_suite_hooks(@suite.around_suite_hooks.dup) do
             run_tests(results, suite_teardown_errors)
           end
@@ -27,8 +27,6 @@ module Smartest
         raise if Smartest.fatal_exception?(error)
 
         suite_errors << error
-      ensure
-        @simple_stub_suite_store = nil
       end
 
       @reporter.finish(
@@ -83,9 +81,7 @@ module Smartest
       end
 
       begin
-        Smartest::SimpleStub.with_process_store(Smartest::SimpleStub::SharedStore.new) do
-          run_around_test_hooks(@suite.around_test_hooks + test_case.around_test_hooks, test_run, run_state)
-        end
+        run_around_test_hooks(@suite.around_test_hooks + test_case.around_test_hooks, test_run, run_state)
       rescue Skipped => skipped_error
         skipped = skipped_error
       rescue Exception => rescued_error
@@ -155,8 +151,7 @@ module Smartest
       @suite_fixture_set ||= FixtureSet.new(
         @suite.fixture_classes,
         context: build_context,
-        scope: :suite,
-        stub_store: @simple_stub_suite_store
+        scope: :suite
       )
     end
 

--- a/lib/smartest/runner.rb
+++ b/lib/smartest/runner.rb
@@ -13,17 +13,22 @@ module Smartest
       suite_teardown_errors = []
       suite_errors = []
       @suite_fixture_set = nil
+      @simple_stub_suite_store = Smartest::SimpleStub::SharedStore.new
 
       @reporter.start(@tests.count)
 
       begin
-        run_around_suite_hooks(@suite.around_suite_hooks.dup) do
-          run_tests(results, suite_teardown_errors)
+        Smartest::SimpleStub.with_process_store(@simple_stub_suite_store, serialize: false) do
+          run_around_suite_hooks(@suite.around_suite_hooks.dup) do
+            run_tests(results, suite_teardown_errors)
+          end
         end
       rescue Exception => error
         raise if Smartest.fatal_exception?(error)
 
         suite_errors << error
+      ensure
+        @simple_stub_suite_store = nil
       end
 
       @reporter.finish(
@@ -78,7 +83,9 @@ module Smartest
       end
 
       begin
-        run_around_test_hooks(@suite.around_test_hooks + test_case.around_test_hooks, test_run, run_state)
+        Smartest::SimpleStub.with_process_store(Smartest::SimpleStub::SharedStore.new) do
+          run_around_test_hooks(@suite.around_test_hooks + test_case.around_test_hooks, test_run, run_state)
+        end
       rescue Skipped => skipped_error
         skipped = skipped_error
       rescue Exception => rescued_error
@@ -148,7 +155,8 @@ module Smartest
       @suite_fixture_set ||= FixtureSet.new(
         @suite.fixture_classes,
         context: build_context,
-        scope: :suite
+        scope: :suite,
+        stub_store: @simple_stub_suite_store
       )
     end
 

--- a/lib/smartest/simple_stub.rb
+++ b/lib/smartest/simple_stub.rb
@@ -9,17 +9,137 @@ module Smartest
     class AlreadyAppliedError < Smartest::Error; end
     class NotAppliedError < Smartest::Error; end
 
+    class FiberLocalStore
+      class << self
+        def current
+          Thread.current[SimpleStub::STORAGE_KEY] ||= new
+        end
+
+        def current_if_defined
+          Thread.current[SimpleStub::STORAGE_KEY]
+        end
+
+        def clear_current_if_empty
+          store = Thread.current[SimpleStub::STORAGE_KEY]
+          Thread.current[SimpleStub::STORAGE_KEY] = nil if store&.empty?
+        end
+      end
+
+      private_class_method :new
+
+      def initialize
+        @stubs = {}
+      end
+
+      def fetch(key, default = nil)
+        @stubs.fetch(key, default)
+      end
+
+      def set(key, implementation)
+        @stubs[key] = implementation
+      end
+
+      def delete(key)
+        @stubs.delete(key)
+      end
+
+      def key?(key)
+        @stubs.key?(key)
+      end
+
+      def empty?
+        @stubs.empty?
+      end
+
+      def clear
+        @stubs.clear
+      end
+
+      def to_h
+        @stubs.dup
+      end
+
+      alias [] fetch
+      alias []= set
+    end
+
+    class SharedStore
+      def initialize
+        @mutex = Mutex.new
+        @stubs = {}
+      end
+
+      def fetch(key, default = nil)
+        @mutex.synchronize { @stubs.fetch(key, default) }
+      end
+
+      def set(key, implementation)
+        @mutex.synchronize { @stubs[key] = implementation }
+      end
+
+      def delete(key)
+        @mutex.synchronize { @stubs.delete(key) }
+      end
+
+      def key?(key)
+        @mutex.synchronize { @stubs.key?(key) }
+      end
+
+      def empty?
+        @mutex.synchronize { @stubs.empty? }
+      end
+
+      def clear
+        @mutex.synchronize { @stubs.clear }
+      end
+
+      def to_h
+        @mutex.synchronize { @stubs.dup }
+      end
+
+      alias [] fetch
+      alias []= set
+    end
+
     class << self
       def implementation_for(klass_key, method_name)
-        current_stubs&.fetch(stub_key(klass_key, method_name), nil)
+        lookup_store&.fetch(stub_key(klass_key, method_name), nil)
       end
 
       def active_stubs
-        Thread.current[STORAGE_KEY] ||= {}
+        current_store
       end
 
       def clear_active_stubs_if_empty
-        Thread.current[STORAGE_KEY] = nil if current_stubs&.empty?
+        return if process_store
+
+        FiberLocalStore.clear_current_if_empty
+      end
+
+      def current_stubs
+        store = lookup_store
+        store&.empty? ? nil : store
+      end
+
+      def current_store
+        process_store || FiberLocalStore.current
+      end
+
+      def with_process_store(store)
+        unless store.respond_to?(:fetch) && store.respond_to?(:set) && store.respond_to?(:delete)
+          raise ArgumentError, "store must respond to fetch, set, and delete"
+        end
+
+        previous_store = nil
+        process_store_mutex.synchronize do
+          previous_store = @process_store
+          @process_store = store
+        end
+
+        yield
+      ensure
+        process_store_mutex.synchronize { @process_store = previous_store }
+        store.clear if store.respond_to?(:clear)
       end
 
       def ensure_dispatcher_method(klass, klass_key, method_name)
@@ -43,10 +163,6 @@ module Smartest
 
       def stub_key(klass_key, method_name)
         [klass_key, method_name]
-      end
-
-      def current_stubs
-        Thread.current[STORAGE_KEY]
       end
 
       def call_implementation(receiver, implementation, args, kwargs, block)
@@ -77,6 +193,18 @@ module Smartest
       end
 
       private
+
+      def process_store
+        process_store_mutex.synchronize { @process_store }
+      end
+
+      def lookup_store
+        process_store || FiberLocalStore.current_if_defined
+      end
+
+      def process_store_mutex
+        @process_store_mutex ||= Mutex.new
+      end
 
       def dispatcher_module_for(klass, klass_key)
         const_name = dispatcher_module_name(klass_key)
@@ -151,7 +279,7 @@ module Smartest
       raise ArgumentError, "block must be given for applying stub" unless @implementation
 
       self.class.ensure_dispatcher_method(@klass, klass_key, @method_name)
-      active_stubs[stub_key] = @implementation
+      active_stubs.set(stub_key, @implementation)
     end
 
     def reset_stub

--- a/lib/smartest/simple_stub.rb
+++ b/lib/smartest/simple_stub.rb
@@ -66,15 +66,6 @@ module Smartest
       def clear
         @mutex.synchronize { @stubs.clear }
       end
-
-      def to_h
-        @mutex.synchronize do
-          @stubs.transform_values { |stack| stack.last.fetch(:implementation) }
-        end
-      end
-
-      alias [] fetch
-      alias []= set
     end
 
     class << self

--- a/lib/smartest/simple_stub.rb
+++ b/lib/smartest/simple_stub.rb
@@ -103,7 +103,13 @@ module Smartest
 
     class << self
       def implementation_for(klass_key, method_name)
-        lookup_store&.fetch(stub_key(klass_key, method_name), nil)
+        key = stub_key(klass_key, method_name)
+
+        lookup_stores.reverse_each do |store|
+          return store.fetch(key) if store.key?(key)
+        end
+
+        nil
       end
 
       def active_stubs
@@ -111,35 +117,32 @@ module Smartest
       end
 
       def clear_active_stubs_if_empty
-        return if process_store
+        return if current_process_store
 
         FiberLocalStore.clear_current_if_empty
       end
 
       def current_stubs
-        store = lookup_store
+        store = current_process_store || FiberLocalStore.current_if_defined
         store&.empty? ? nil : store
       end
 
       def current_store
-        process_store || FiberLocalStore.current
+        current_process_store || FiberLocalStore.current
       end
 
-      def with_process_store(store)
+      def with_process_store(store, serialize: true, clear: true)
         unless store.respond_to?(:fetch) && store.respond_to?(:set) && store.respond_to?(:delete)
           raise ArgumentError, "store must respond to fetch, set, and delete"
         end
 
-        previous_store = nil
-        process_store_mutex.synchronize do
-          previous_store = @process_store
-          @process_store = store
+        if serialize && !process_store_execution_mutex.owned?
+          process_store_execution_mutex.synchronize do
+            with_pushed_process_store(store, clear: clear) { yield }
+          end
+        else
+          with_pushed_process_store(store, clear: clear) { yield }
         end
-
-        yield
-      ensure
-        process_store_mutex.synchronize { @process_store = previous_store }
-        store.clear if store.respond_to?(:clear)
       end
 
       def ensure_dispatcher_method(klass, klass_key, method_name)
@@ -194,16 +197,43 @@ module Smartest
 
       private
 
-      def process_store
-        process_store_mutex.synchronize { @process_store }
+      def with_pushed_process_store(store, clear:)
+        process_store_mutex.synchronize do
+          process_store_stack << store
+        end
+
+        yield
+      ensure
+        process_store_mutex.synchronize do
+          stack = process_store_stack
+          index = stack.rindex { |entry| entry.equal?(store) }
+          stack.delete_at(index) if index
+        end
+        store.clear if clear && store.respond_to?(:clear)
       end
 
-      def lookup_store
-        process_store || FiberLocalStore.current_if_defined
+      def current_process_store
+        process_store_mutex.synchronize { process_store_stack.last }
+      end
+
+      def lookup_stores
+        process_stores = process_store_mutex.synchronize { process_store_stack.dup }
+        return process_stores if process_stores.any?
+
+        store = FiberLocalStore.current_if_defined
+        store ? [store] : []
       end
 
       def process_store_mutex
         @process_store_mutex ||= Mutex.new
+      end
+
+      def process_store_execution_mutex
+        @process_store_execution_mutex ||= Mutex.new
+      end
+
+      def process_store_stack
+        @process_store_stack ||= []
       end
 
       def dispatcher_module_for(klass, klass_key)

--- a/lib/smartest/simple_stub.rb
+++ b/lib/smartest/simple_stub.rb
@@ -14,19 +14,49 @@ module Smartest
       end
 
       def fetch(key, default = nil)
-        @mutex.synchronize { @stubs.fetch(key, default) }
+        @mutex.synchronize do
+          stack = @stubs[key]
+          stack && !stack.empty? ? stack.last.fetch(:implementation) : default
+        end
       end
 
       def set(key, implementation)
-        @mutex.synchronize { @stubs[key] = implementation }
+        @mutex.synchronize do
+          entry = { implementation: implementation }
+          (@stubs[key] ||= []) << entry
+          entry
+        end
       end
 
-      def delete(key)
-        @mutex.synchronize { @stubs.delete(key) }
+      def delete(key, entry = nil)
+        @mutex.synchronize do
+          stack = @stubs[key]
+          if stack && !stack.empty?
+            removed = if entry
+              index = stack.rindex { |candidate| candidate.equal?(entry) }
+              index ? stack.delete_at(index) : nil
+            else
+              stack.pop
+            end
+
+            @stubs.delete(key) if stack.empty?
+            removed&.fetch(:implementation)
+          end
+        end
       end
 
       def key?(key)
-        @mutex.synchronize { @stubs.key?(key) }
+        @mutex.synchronize do
+          stack = @stubs[key]
+          !!(stack && !stack.empty?)
+        end
+      end
+
+      def include?(key, entry)
+        @mutex.synchronize do
+          stack = @stubs[key]
+          stack ? stack.any? { |candidate| candidate.equal?(entry) } : false
+        end
       end
 
       def empty?
@@ -38,7 +68,9 @@ module Smartest
       end
 
       def to_h
-        @mutex.synchronize { @stubs.dup }
+        @mutex.synchronize do
+          @stubs.transform_values { |stack| stack.last.fetch(:implementation) }
+        end
       end
 
       alias [] fetch
@@ -204,25 +236,27 @@ module Smartest
     end
 
     def apply
-      return if stub_defined?
+      return if applied?
 
       apply_stub
     end
 
     def apply!
-      raise AlreadyAppliedError, "stub for #{@klass}##{@method_name} is already applied" if stub_defined?
+      raise AlreadyAppliedError, "stub for #{@klass}##{@method_name} is already applied" if applied?
 
       apply_stub
     end
 
     def reset
-      return unless stub_defined?
+      return if @stub_entry && !applied?
+      return unless applied? || stub_available?
 
       reset_stub
     end
 
     def reset!
-      raise NotAppliedError, "stub for #{@klass}##{@method_name} is not applied" unless stub_defined?
+      raise NotAppliedError, "stub for #{@klass}##{@method_name} is not applied" if @stub_entry && !applied?
+      raise NotAppliedError, "stub for #{@klass}##{@method_name} is not applied" unless applied? || stub_available?
 
       reset_stub
     end
@@ -233,11 +267,12 @@ module Smartest
       raise ArgumentError, "block must be given for applying stub" unless @implementation
 
       self.class.ensure_dispatcher_method(@klass, klass_key, @method_name)
-      active_stubs.set(stub_key, @implementation)
+      @stub_entry = active_stubs.set(stub_key, @implementation)
     end
 
     def reset_stub
-      active_stubs.delete(stub_key)
+      active_stubs.delete(stub_key, @stub_entry)
+      @stub_entry = nil
       self.class.clear_active_stubs_if_empty
     end
 
@@ -253,7 +288,11 @@ module Smartest
       @klass_key ||= Digest::SHA256.hexdigest(@klass.object_id.to_s)
     end
 
-    def stub_defined?
+    def applied?
+      @stub_entry && self.class.current_stubs&.include?(stub_key, @stub_entry)
+    end
+
+    def stub_available?
       self.class.current_stubs&.key?(stub_key)
     end
   end

--- a/lib/smartest/simple_stub.rb
+++ b/lib/smartest/simple_stub.rb
@@ -4,66 +4,10 @@ require "digest"
 
 module Smartest
   class SimpleStub
-    STORAGE_KEY = :__smartest_simple_stub
-
     class AlreadyAppliedError < Smartest::Error; end
     class NotAppliedError < Smartest::Error; end
 
-    class FiberLocalStore
-      class << self
-        def current
-          Thread.current[SimpleStub::STORAGE_KEY] ||= new
-        end
-
-        def current_if_defined
-          Thread.current[SimpleStub::STORAGE_KEY]
-        end
-
-        def clear_current_if_empty
-          store = Thread.current[SimpleStub::STORAGE_KEY]
-          Thread.current[SimpleStub::STORAGE_KEY] = nil if store&.empty?
-        end
-      end
-
-      private_class_method :new
-
-      def initialize
-        @stubs = {}
-      end
-
-      def fetch(key, default = nil)
-        @stubs.fetch(key, default)
-      end
-
-      def set(key, implementation)
-        @stubs[key] = implementation
-      end
-
-      def delete(key)
-        @stubs.delete(key)
-      end
-
-      def key?(key)
-        @stubs.key?(key)
-      end
-
-      def empty?
-        @stubs.empty?
-      end
-
-      def clear
-        @stubs.clear
-      end
-
-      def to_h
-        @stubs.dup
-      end
-
-      alias [] fetch
-      alias []= set
-    end
-
-    class SharedStore
+    class LocalStore
       def initialize
         @mutex = Mutex.new
         @stubs = {}
@@ -104,12 +48,10 @@ module Smartest
     class << self
       def implementation_for(klass_key, method_name)
         key = stub_key(klass_key, method_name)
+        store = current_store_if_defined
+        return nil unless store&.key?(key)
 
-        lookup_stores.reverse_each do |store|
-          return store.fetch(key) if store.key?(key)
-        end
-
-        nil
+        store.fetch(key)
       end
 
       def active_stubs
@@ -117,32 +59,33 @@ module Smartest
       end
 
       def clear_active_stubs_if_empty
-        return if current_process_store
-
-        FiberLocalStore.clear_current_if_empty
+        @default_store = nil if @default_store&.empty?
       end
 
       def current_stubs
-        store = current_process_store || FiberLocalStore.current_if_defined
+        store = current_store_if_defined
         store&.empty? ? nil : store
       end
 
       def current_store
-        current_process_store || FiberLocalStore.current
+        active_store || default_store
       end
 
-      def with_process_store(store, serialize: true, clear: true)
+      def with_store(store, clear: true)
         unless store.respond_to?(:fetch) && store.respond_to?(:set) && store.respond_to?(:delete)
           raise ArgumentError, "store must respond to fetch, set, and delete"
         end
 
-        if serialize && !process_store_execution_mutex.owned?
-          process_store_execution_mutex.synchronize do
-            with_pushed_process_store(store, clear: clear) { yield }
-          end
-        else
-          with_pushed_process_store(store, clear: clear) { yield }
+        previous_store = nil
+        store_mutex.synchronize do
+          previous_store = @active_store
+          @active_store = store
         end
+
+        yield
+      ensure
+        store_mutex.synchronize { @active_store = previous_store }
+        store.clear if clear && store.respond_to?(:clear)
       end
 
       def ensure_dispatcher_method(klass, klass_key, method_name)
@@ -197,43 +140,24 @@ module Smartest
 
       private
 
-      def with_pushed_process_store(store, clear:)
-        process_store_mutex.synchronize do
-          process_store_stack << store
-        end
-
-        yield
-      ensure
-        process_store_mutex.synchronize do
-          stack = process_store_stack
-          index = stack.rindex { |entry| entry.equal?(store) }
-          stack.delete_at(index) if index
-        end
-        store.clear if clear && store.respond_to?(:clear)
+      def current_store_if_defined
+        active_store || default_store_if_defined
       end
 
-      def current_process_store
-        process_store_mutex.synchronize { process_store_stack.last }
+      def active_store
+        store_mutex.synchronize { @active_store }
       end
 
-      def lookup_stores
-        process_stores = process_store_mutex.synchronize { process_store_stack.dup }
-        return process_stores if process_stores.any?
-
-        store = FiberLocalStore.current_if_defined
-        store ? [store] : []
+      def default_store
+        store_mutex.synchronize { @default_store ||= LocalStore.new }
       end
 
-      def process_store_mutex
-        @process_store_mutex ||= Mutex.new
+      def default_store_if_defined
+        store_mutex.synchronize { @default_store }
       end
 
-      def process_store_execution_mutex
-        @process_store_execution_mutex ||= Mutex.new
-      end
-
-      def process_store_stack
-        @process_store_stack ||= []
+      def store_mutex
+        @store_mutex ||= Mutex.new
       end
 
       def dispatcher_module_for(klass, klass_key)

--- a/smartest/simple_stub_test.rb
+++ b/smartest/simple_stub_test.rb
@@ -377,24 +377,12 @@ test("simple stub is shared with threads during a test run") do
   expect(subject.name).to eq("original Alice")
 end
 
-test("simple stub FiberLocalStore current is scoped to the current fiber") do
-  main_store = Smartest::SimpleStub::FiberLocalStore.current
-
-  expect(Smartest::SimpleStub::FiberLocalStore.current).to eq(main_store)
-
-  fiber_store = Fiber.new do
-    Smartest::SimpleStub::FiberLocalStore.current
-  end.resume
-
-  expect(fiber_store == main_store).to eq(false)
-end
-
-test("simple stub process store is visible across threads") do
+test("simple stub explicit local store is visible across threads") do
   subject = SimpleStubSelfTestSubject.new("Alice")
   queue = Queue.new
-  store = Smartest::SimpleStub::SharedStore.new
+  store = Smartest::SimpleStub::LocalStore.new
 
-  Smartest::SimpleStub.with_process_store(store) do
+  Smartest::SimpleStub.with_store(store) do
     stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "shared #{@name}" }
     stub.apply!
 
@@ -421,12 +409,17 @@ test("simple stub process store is visible across threads") do
   expect(subject.name).to eq("original Alice")
 end
 
-test("simple stub process store is restored after errors") do
+test("simple stub does not expose legacy store constants") do
+  expect(Smartest::SimpleStub.const_defined?(:FiberLocalStore, false)).to eq(false)
+  expect(Smartest::SimpleStub.const_defined?(:SharedStore, false)).to eq(false)
+end
+
+test("simple stub explicit local store is restored after errors") do
   subject = SimpleStubSelfTestSubject.new("Alice")
-  store = Smartest::SimpleStub::SharedStore.new
+  store = Smartest::SimpleStub::LocalStore.new
 
   error = SimpleStubSelfTest.capture_error(RuntimeError) do
-    Smartest::SimpleStub.with_process_store(store) do
+    Smartest::SimpleStub.with_store(store) do
       Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "shared #{@name}" }.apply!
       expect(subject.name).to eq("shared Alice")
       raise "shared store failure"

--- a/smartest/simple_stub_test.rb
+++ b/smartest/simple_stub_test.rb
@@ -328,6 +328,67 @@ test("simple stub can differ per thread") do
   expect(subject.name).to eq("original Alice")
 end
 
+test("simple stub FiberLocalStore current is scoped to the current fiber") do
+  main_store = Smartest::SimpleStub::FiberLocalStore.current
+
+  expect(Smartest::SimpleStub::FiberLocalStore.current).to eq(main_store)
+
+  fiber_store = Fiber.new do
+    Smartest::SimpleStub::FiberLocalStore.current
+  end.resume
+
+  expect(fiber_store == main_store).to eq(false)
+end
+
+test("simple stub process store is visible across threads") do
+  subject = SimpleStubSelfTestSubject.new("Alice")
+  queue = Queue.new
+  store = Smartest::SimpleStub::SharedStore.new
+
+  Smartest::SimpleStub.with_process_store(store) do
+    stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "shared #{@name}" }
+    stub.apply!
+
+    thread = Thread.new do
+      queue << subject.name
+    rescue Exception => error
+      queue << error
+    end
+
+    begin
+      expect(subject.name).to eq("shared Alice")
+      thread_result = queue.pop
+      raise thread_result if thread_result.is_a?(Exception)
+
+      expect(thread_result).to eq("shared Alice")
+      thread.join
+    ensure
+      stub.reset
+      thread.kill if thread&.alive?
+    end
+  end
+
+  expect(store.empty?).to eq(true)
+  expect(subject.name).to eq("original Alice")
+end
+
+test("simple stub process store is restored after errors") do
+  subject = SimpleStubSelfTestSubject.new("Alice")
+  store = Smartest::SimpleStub::SharedStore.new
+
+  error = SimpleStubSelfTest.capture_error(RuntimeError) do
+    Smartest::SimpleStub.with_process_store(store) do
+      Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "shared #{@name}" }.apply!
+      expect(subject.name).to eq("shared Alice")
+      raise "shared store failure"
+    end
+  end
+
+  expect(error.message).to eq("shared store failure")
+  expect(store.empty?).to eq(true)
+  expect(subject.name).to eq("original Alice")
+end
+
 test("simple stub supports safe and strict apply reset APIs") do
   stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "stubbed" }
 

--- a/smartest/simple_stub_test.rb
+++ b/smartest/simple_stub_test.rb
@@ -158,6 +158,63 @@ test("simple_stub applies and resets singleton methods from fixture teardown") d
   expect(status).to eq(0)
 end
 
+test("simple stubs created from suite fixtures stay active until suite teardown") do
+  fixture_class = Class.new(Smartest::Fixture) do
+    suite_fixture :suite_stubbed_name do
+      simple_stub_any_instance_of(SimpleStubSelfTestSubject, :name) { "suite #{@name}" }
+      :suite_stubbed_name
+    end
+  end
+
+  suite = Smartest::Suite.new
+  suite.fixture_classes.add(fixture_class)
+  suite.tests.add(
+    SimpleStubSelfTest.test_case(
+      "activates suite stub",
+      proc do |suite_stubbed_name:|
+        expect(suite_stubbed_name).to eq(:suite_stubbed_name)
+        expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("suite Alice")
+      end
+    )
+  )
+  suite.tests.add(
+    SimpleStubSelfTest.test_case(
+      "keeps suite stub active",
+      proc { expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("suite Alice") }
+    )
+  )
+
+  status, = SimpleStubSelfTest.run_suite(suite)
+
+  expect(status).to eq(0)
+  expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("original Alice")
+end
+
+test("simple stubs created from around_suite stay active until the hook resets them") do
+  suite = Smartest::Suite.new
+  suite.around_suite_hooks << proc do |suite_run|
+    stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "around suite #{@name}" }
+    stub.apply!
+
+    begin
+      suite_run.run
+    ensure
+      stub.reset
+    end
+  end
+  suite.tests.add(
+    SimpleStubSelfTest.test_case(
+      "uses around_suite stub",
+      proc { expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("around suite Alice") }
+    )
+  )
+
+  status, = SimpleStubSelfTest.run_suite(suite)
+
+  expect(status).to eq(0)
+  expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("original Alice")
+end
+
 test("with_stub_const applies and resets existing constants in test body blocks") do
   result = with_stub_const("SimpleStubSelfTestConfig::PROVIDER", :stubbed_provider) do
     expect(SimpleStubSelfTestConfig::PROVIDER).to eq(:stubbed_provider)
@@ -273,7 +330,7 @@ test("simple stub preserves receiver self and method blocks") do
   expect(subject.yielding_greeting("Hi") { |message| message }).to eq("Hi, Alice")
 end
 
-test("simple stub is scoped to the current fiber") do
+test("simple stub is shared with fibers during a test run") do
   subject = SimpleStubSelfTestSubject.new("Alice")
   stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "stubbed #{@name}" }
 
@@ -282,7 +339,7 @@ test("simple stub is scoped to the current fiber") do
   begin
     expect(subject.name).to eq("stubbed Alice")
     Fiber.new do
-      expect(subject.name).to eq("original Alice")
+      expect(subject.name).to eq("stubbed Alice")
     end.resume
   ensure
     stub.reset
@@ -291,37 +348,29 @@ test("simple stub is scoped to the current fiber") do
   expect(subject.name).to eq("original Alice")
 end
 
-test("simple stub can differ per thread") do
+test("simple stub is shared with threads during a test run") do
   subject = SimpleStubSelfTestSubject.new("Alice")
   queue = Queue.new
-  main_stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "main #{@name}" }
+  stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "shared #{@name}" }
 
-  main_stub.apply!
+  stub.apply!
 
   thread = Thread.new do
-    thread_stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "thread #{@name}" }
-    thread_stub.apply!
-
-    begin
-      queue << subject.name
-    rescue Exception => error
-      queue << error
-    ensure
-      thread_stub.reset
-    end
+    queue << subject.name
+  rescue Exception => error
+    queue << error
   end
 
   begin
-    expect(subject.name).to eq("main Alice")
+    expect(subject.name).to eq("shared Alice")
 
     thread_result = queue.pop
     raise thread_result if thread_result.is_a?(Exception)
 
-    expect(thread_result).to eq("thread Alice")
+    expect(thread_result).to eq("shared Alice")
     thread.join
-    expect(subject.name).to eq("main Alice")
   ensure
-    main_stub.reset
+    stub.reset
     thread.kill if thread.alive?
   end
 

--- a/smartest/simple_stub_test.rb
+++ b/smartest/simple_stub_test.rb
@@ -8,12 +8,13 @@ require "stringio"
 module SimpleStubSelfTest
   module_function
 
-  def test_case(name, block)
+  def test_case(name, block, around_test_hooks: [])
     Smartest::TestCase.new(
       name: name,
       metadata: {},
       block: block,
-      location: caller_locations(1, 1).first
+      location: caller_locations(1, 1).first,
+      around_test_hooks: around_test_hooks
     )
   end
 
@@ -206,6 +207,91 @@ test("simple stubs created from around_suite stay active until the hook resets t
     SimpleStubSelfTest.test_case(
       "uses around_suite stub",
       proc { expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("around suite Alice") }
+    )
+  )
+
+  status, = SimpleStubSelfTest.run_suite(suite)
+
+  expect(status).to eq(0)
+  expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("original Alice")
+end
+
+test("test-scoped around_test simple stubs restore around_suite simple stubs") do
+  suite = Smartest::Suite.new
+  suite.around_suite_hooks << proc do |suite_run|
+    stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "suite #{@name}" }
+    stub.apply!
+
+    begin
+      suite_run.run
+    ensure
+      stub.reset
+    end
+  end
+
+  test_override = proc do |test_run|
+    stub = Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "test #{@name}" }
+    stub.apply!
+
+    begin
+      test_run.run
+    ensure
+      stub.reset
+    end
+  end
+
+  suite.tests.add(
+    SimpleStubSelfTest.test_case(
+      "uses around_test override",
+      proc { expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("test Alice") },
+      around_test_hooks: [test_override]
+    )
+  )
+  suite.tests.add(
+    SimpleStubSelfTest.test_case(
+      "restores around_suite stub",
+      proc { expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("suite Alice") }
+    )
+  )
+
+  status, = SimpleStubSelfTest.run_suite(suite)
+
+  expect(status).to eq(0)
+  expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("original Alice")
+end
+
+test("test-scoped simple stubs can override suite simple stubs and restore them on teardown") do
+  fixture_class = Class.new(Smartest::Fixture) do
+    suite_fixture :suite_stubbed_name do
+      simple_stub_any_instance_of(SimpleStubSelfTestSubject, :name) { "suite #{@name}" }
+      :suite_stubbed_name
+    end
+
+    fixture :test_stubbed_name do |suite_stubbed_name:|
+      expect(suite_stubbed_name).to eq(:suite_stubbed_name)
+      simple_stub_any_instance_of(SimpleStubSelfTestSubject, :name) { "test #{@name}" }
+      :test_stubbed_name
+    end
+  end
+
+  suite = Smartest::Suite.new
+  suite.fixture_classes.add(fixture_class)
+  suite.tests.add(
+    SimpleStubSelfTest.test_case(
+      "uses test override",
+      proc do |test_stubbed_name:|
+        expect(test_stubbed_name).to eq(:test_stubbed_name)
+        expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("test Alice")
+      end
+    )
+  )
+  suite.tests.add(
+    SimpleStubSelfTest.test_case(
+      "restores suite stub after test teardown",
+      proc do |suite_stubbed_name:|
+        expect(suite_stubbed_name).to eq(:suite_stubbed_name)
+        expect(SimpleStubSelfTestSubject.new("Alice").name).to eq("suite Alice")
+      end
     )
   )
 
@@ -439,7 +525,7 @@ test("simple stub supports safe and strict apply reset APIs") do
 
   begin
     error = SimpleStubSelfTest.capture_error(Smartest::SimpleStub::AlreadyAppliedError) do
-      Smartest::SimpleStub.new(SimpleStubSelfTestSubject, :name) { "other" }.apply!
+      stub.apply!
     end
 
     expect(error.message).to eq("stub for SimpleStubSelfTestSubject#name is already applied")

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -2243,9 +2243,7 @@ test("cli rails init generator creates Rails browser scaffold and installation c
 
     helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
     expect(helper_contents).to include("use_matcher PredicateMatcher\n  use_fixture RailsSystemFixture\n  use_matcher PlaywrightMatcher\n  suite.run")
-    expect(helper_contents).to include("around_test do |test|")
-    expect(helper_contents).to include("store = Smartest::SimpleStub::SharedStore.new")
-    expect(helper_contents).to include("Smartest::SimpleStub.with_process_store(store) do")
+    expect(helper_contents).not_to include("Smartest::SimpleStub.with_process_store")
 
     gemfile_contents = File.read(File.join(dir, "Gemfile"))
     expect(gemfile_contents).to include('gem "playwright-ruby-client", group: :test')
@@ -2281,14 +2279,6 @@ test("cli rails init generator skips duplicate registration and dependencies") d
         use_matcher PlaywrightMatcher
         suite.run
       end
-
-      around_test do |test|
-        store = Smartest::SimpleStub::SharedStore.new
-
-        Smartest::SimpleStub.with_process_store(store) do
-          test.run
-        end
-      end
     RUBY
 
     commands = []
@@ -2307,7 +2297,7 @@ test("cli rails init generator skips duplicate registration and dependencies") d
     expect(status).to eq(0)
     helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
     expect(helper_contents.scan("use_fixture RailsSystemFixture").length).to eq(1)
-    expect(helper_contents.scan("Smartest::SimpleStub.with_process_store").length).to eq(1)
+    expect(helper_contents).not_to include("Smartest::SimpleStub.with_process_store")
     expect(commands).to eq(
       [
         [["bundle", "install"], dir],

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -1723,6 +1723,7 @@ test("cli prints help") do
   expect(stdout).not_to include("Run a browser test file")
   expect(stdout).to include("bundle exec smartest --init")
   expect(stdout).to include("bundle exec smartest --init-browser")
+  expect(stdout).to include("bundle exec smartest --init-rails")
   expect(stdout).to include("--profile N")
   expect(stdout).to include("smartest/**/*_test.rb")
 end
@@ -1741,6 +1742,7 @@ test("cli explains how to initialize when default smartest directory is missing"
     expect(stdout).to include("No smartest/ directory found.")
     expect(stdout).to include("bundle exec smartest --init")
     expect(stdout).to include("bundle exec smartest --init-browser")
+    expect(stdout).to include("bundle exec smartest --init-rails")
     expect(stdout).to include("bundle exec smartest --help")
   end
 end
@@ -2195,6 +2197,125 @@ test("cli browser init generator skips npm init when package.json already exists
         [["./node_modules/.bin/playwright", "install"], dir]
       ]
     )
+    expect(output.string).not_to include("npm init --yes")
+  end
+end
+
+test("cli rails init generator creates Rails browser scaffold and installation commands") do
+  Dir.mktmpdir do |dir|
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "rails"
+      gem "smartest"
+    RUBY
+
+    commands = []
+    output = StringIO.new
+    generator = Smartest::InitRailsGenerator.new(
+      root: dir,
+      output: output,
+      command_runner: ->(command, chdir:) {
+        commands << [command, chdir]
+        true
+      }
+    )
+
+    status = generator.run
+
+    expect(status).to eq(0)
+    rails_fixture = File.read(File.join(dir, "smartest/fixtures/rails_system_fixture.rb"))
+    expect(rails_fixture).to include("class SmartestRailsTestServer")
+    expect(rails_fixture).to include('@requested_port = port || ENV["SMARTEST_RAILS_PORT"]&.to_i || 0')
+    expect(rails_fixture).to include("listener = @server.add_tcp_listener(@host, @requested_port)")
+    expect(rails_fixture).to include("class RailsSystemFixture < Smartest::Fixture")
+    expect(rails_fixture).to include("suite_fixture :rails_server")
+    expect(rails_fixture).to include('require File.expand_path("../../config/environment", __dir__)')
+    expect(rails_fixture).to include("suite_fixture :base_url")
+    expect(rails_fixture).to include("fixture :browser_context do |base_url:, browser:|")
+    expect(rails_fixture).to include("context = browser.new_context(baseURL: base_url)")
+    expect(rails_fixture).to include("fixture :page do |browser_context:|")
+
+    example_test = File.read(File.join(dir, "smartest/example_rails_system_test.rb"))
+    expect(example_test).to include('test("loads the Rails application") do |page:|')
+    expect(example_test).to include('response = page.goto("/")')
+    expect(example_test).to include("expect(response.status).to be_between(200, 599)")
+
+    helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
+    expect(helper_contents).to include("use_matcher PredicateMatcher\n  use_fixture RailsSystemFixture\n  use_matcher PlaywrightMatcher\n  suite.run")
+    expect(helper_contents).to include("around_test do |test|")
+    expect(helper_contents).to include("store = Smartest::SimpleStub::SharedStore.new")
+    expect(helper_contents).to include("Smartest::SimpleStub.with_process_store(store) do")
+
+    gemfile_contents = File.read(File.join(dir, "Gemfile"))
+    expect(gemfile_contents).to include('gem "playwright-ruby-client", group: :test')
+    expect(commands).to eq(
+      [
+        [["bundle", "install"], dir],
+        [["npm", "init", "--yes"], dir],
+        [["npm", "install", "playwright", "--save-dev"], dir],
+        [["./node_modules/.bin/playwright", "install"], dir]
+      ]
+    )
+    expect(output.string).to include("Run your Rails browser test suite with: bundle exec smartest smartest/example_rails_system_test.rb")
+  end
+end
+
+test("cli rails init generator skips duplicate registration and dependencies") do
+  Dir.mktmpdir do |dir|
+    FileUtils.mkdir_p(File.join(dir, "smartest/fixtures"))
+    FileUtils.mkdir_p(File.join(dir, "smartest/matchers"))
+    File.write(File.join(dir, "package.json"), "{\n  \"name\": \"existing\"\n}\n")
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "smartest"
+      gem "playwright-ruby-client", group: :test
+    RUBY
+    File.write(File.join(dir, "smartest/test_helper.rb"), <<~RUBY)
+      require "smartest/autorun"
+
+      around_suite do |suite|
+        use_matcher PredicateMatcher
+        use_fixture RailsSystemFixture
+        use_matcher PlaywrightMatcher
+        suite.run
+      end
+
+      around_test do |test|
+        store = Smartest::SimpleStub::SharedStore.new
+
+        Smartest::SimpleStub.with_process_store(store) do
+          test.run
+        end
+      end
+    RUBY
+
+    commands = []
+    output = StringIO.new
+    generator = Smartest::InitRailsGenerator.new(
+      root: dir,
+      output: output,
+      command_runner: ->(command, chdir:) {
+        commands << [command, chdir]
+        true
+      }
+    )
+
+    status = generator.run
+
+    expect(status).to eq(0)
+    helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
+    expect(helper_contents.scan("use_fixture RailsSystemFixture").length).to eq(1)
+    expect(helper_contents.scan("Smartest::SimpleStub.with_process_store").length).to eq(1)
+    expect(commands).to eq(
+      [
+        [["bundle", "install"], dir],
+        [["npm", "install", "playwright", "--save-dev"], dir],
+        [["./node_modules/.bin/playwright", "install"], dir]
+      ]
+    )
+    expect(output.string).to include("exist   Gemfile playwright-ruby-client")
     expect(output.string).not_to include("npm init --yes")
   end
 end

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -2243,7 +2243,8 @@ test("cli rails init generator creates Rails browser scaffold and installation c
 
     helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
     expect(helper_contents).to include("use_matcher PredicateMatcher\n  use_fixture RailsSystemFixture\n  use_matcher PlaywrightMatcher\n  suite.run")
-    expect(helper_contents).not_to include("Smartest::SimpleStub.with_process_store")
+    expect(helper_contents).not_to include("Smartest::SimpleStub.with_store")
+    expect(helper_contents).not_to include("Smartest::SimpleStub::LocalStore")
 
     gemfile_contents = File.read(File.join(dir, "Gemfile"))
     expect(gemfile_contents).to include('gem "playwright-ruby-client", group: :test')
@@ -2297,7 +2298,8 @@ test("cli rails init generator skips duplicate registration and dependencies") d
     expect(status).to eq(0)
     helper_contents = File.read(File.join(dir, "smartest/test_helper.rb"))
     expect(helper_contents.scan("use_fixture RailsSystemFixture").length).to eq(1)
-    expect(helper_contents).not_to include("Smartest::SimpleStub.with_process_store")
+    expect(helper_contents).not_to include("Smartest::SimpleStub.with_store")
+    expect(helper_contents).not_to include("Smartest::SimpleStub::LocalStore")
     expect(commands).to eq(
       [
         [["bundle", "install"], dir],


### PR DESCRIPTION
## Summary

- Add `bundle exec smartest --init-rails` and a Rails browser-test scaffold generator.
- Generate a same-process Puma-backed Rails server fixture with automatic port selection and `SMARTEST_RAILS_PORT` override.
- Refactor `Smartest::SimpleStub` so the runner creates one suite-wide process-shared store for the full suite run.
- Stack method stubs per target method so test-scoped overrides restore suite-scoped stubs when they tear down.
- Remove the legacy fiber-local store path and the earlier store stack/test-store split; method stubs are shared across Threads and Fibers in the same Ruby process.
- Keep store setup internal to the runner and avoid generating any user-facing store setup.
- Add tests and documentation for Rails browser tests and shared stub scope.

## Validation

- `bundle exec rake test`
- `npm run build` from `documentation/`