### PR TITLE
Restructure docs sidebar and simplify page titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,11 @@ Before finishing a task:
 6. If documentation did not need changes, explain why in the final response.
 
 Keep documentation examples runnable and aligned with the current MVP. Do not document future APIs as available behavior.
+
+## Documentation Editorial Conventions
+
+For the structural conventions of the Docusaurus site under `documentation/`
+— what Smartest's framing is, the sidebar shape, each page's primary purpose,
+the `title` / `sidebar_label` / `description` split, and the overlap warning
+between *Test a Rails app locally* and *vs Capybara* — see
+`documentation/AGENTS.md`. Do not re-derive these decisions per change.

--- a/documentation/AGENTS.md
+++ b/documentation/AGENTS.md
@@ -1,0 +1,180 @@
+# Documentation Editorial Conventions
+
+This file captures the framing and structure conventions for the Docusaurus
+site under `documentation/`. The goal is to keep the docs consistent without
+re-deciding the same questions each time.
+
+- For build / deploy instructions, see `README.md` in this directory.
+- For the rule that implementation changes must update docs in the same PR,
+  see the top-level `AGENTS.md`.
+
+## What Smartest is — the framing to assume
+
+Smartest is a Ruby test runner whose purpose is **smarter Ruby browser
+testing**, not a slightly nicer RSpec alternative. The library exists because:
+
+- Mainstream Ruby browser testing today is unit-test-era architecture
+  (RSpec / Minitest) with browser automation (Capybara / Playwright) bolted
+  on top.
+- Playwright Test changed the test runner because the target domain changed —
+  browser testing is not unit testing. Smartest applies that same lesson to
+  Ruby.
+- Pytest-style fixture injection happens to be the cleanest way to express
+  what a browser test actually depends on (server, browser, page, app state,
+  stubs, route helpers, …) at the test signature.
+
+When a page assumes a reader who is "considering Smartest", assume that
+reader is feeling pain in their existing Rails browser-test suite — flaky
+async tests, hard-to-customize Capybara waits, hidden setup — not someone
+shopping for a new unit-test runner. Pages do **not** need to re-establish
+this framing every time; link to `intro.md` (Why Smartest) or
+`playwright-browser-tests.md` (Why Smartest browser tests) instead.
+
+## Sidebar structure
+
+The sidebar is grouped by reader goal, not by feature surface area. The shape
+is modeled after the Vitest guide:
+
+```
+Introduction
+  Why Smartest
+  Getting Started
+Learn
+  Writing Tests
+  Fixtures
+  Stubs
+  Matchers
+  Helpers
+  Skipping Tests
+  Running Tests
+Browser Tests
+  Why Smartest browser tests       ← entry / positioning
+  Test a Rails app locally
+  (future) Test a Rails app in Docker
+Comparisons
+  vs Pytest
+  vs RSpec
+  vs Minitest
+  vs Capybara
+Reference
+  Errors
+```
+
+Top-level categories should answer "what reader goal is this for?", not
+"what Smartest concept is this?". Keep new pages aligned with this shape.
+
+## Page roles — primary purpose per page
+
+| Page | Primary purpose |
+| --- | --- |
+| `intro.md` (Why Smartest) | Why Smartest exists at the project level. Sets the framing for the whole site. |
+| `getting-started.md` | Smallest runnable test, end-to-end. |
+| `writing-tests.md` | Test definition, expectations, basic structure. |
+| `running-test-suites.md` (Running Tests) | `autorun` and the CLI. |
+| `skipping-tests.md` | `skip` / `pending`. |
+| `fixtures.md` | The class-based fixture model in depth — test-scoped, suite-scoped, dependencies, teardown. |
+| `stubs.md` | Method stubs that reset from fixture teardown. |
+| `matchers.md` | Built-in and custom matchers. |
+| `helpers.md` | Registering helper modules via `around_test`. |
+| `playwright-browser-tests.md` (Why Smartest browser tests) | Browser Tests entry. Why-style positioning followed by Quick Start and "How it works" for the generic Playwright scaffold. |
+| `rails-browser-tests.md` (Test a Rails app locally) | Concrete how-to for Rails browser tests against a local in-process Rails server. Aimed at engineers feeling Rails system-test pain. |
+| `pytest-style-fixtures-for-ruby.md` (vs Pytest) | Comparison only. Map pytest concepts to Smartest. |
+| `smartest-vs-rspec.md` (vs RSpec) | Comparison only. RSpec `let` / `before` → Smartest fixtures. |
+| `smartest-vs-minitest.md` (vs Minitest) | Comparison only. Minitest setup / teardown → Smartest fixtures. |
+| `smartest-vs-capybara.md` (vs Capybara) | Comparison. When to keep Capybara (simple synchronous flows, login forms) vs when migrating pays off (async-heavy stability-critical tests). Frames `with_playwright_page` as the awkward escape hatch Smartest replaces. |
+| `reference/errors.md` | Reference for Smartest error classes. |
+
+When the role of a page is ambiguous, prefer **role-by-reader-goal** over
+**role-by-API-coverage**. A reader landing on the page should immediately
+know what question this page answers for them.
+
+## Title, sidebar label, and description
+
+Three frontmatter fields are deliberately decoupled:
+
+- `title:` — the `<title>` tag, the page `<h1>`, and (by default) the
+  sidebar entry. Keep it concrete and short. **Do not stuff SEO keywords
+  here.** Past mistake we have already corrected: titles like
+  *"Pytest-style Fixtures in Ruby"* or *"Playwright-style Browser Tests in
+  Ruby"* — never bring those back.
+- `sidebar_label:` — set this **only** when the sidebar entry should be
+  shorter than the page title. Currently used for `vs Pytest`, `vs RSpec`,
+  `vs Minitest`, `vs Capybara`. For pages whose title is already short
+  (e.g. `Fixtures`, `Stubs`), omit `sidebar_label`.
+- `description:` — `<meta name="description">`. This is where SEO phrasing
+  goes. Aim for one full sentence that names the feature *and* the
+  user-facing benefit.
+
+When adding a page: write the `<h1>` first, copy it into `title:`, write a
+focused `description:`, and add `sidebar_label:` only if the sidebar context
+genuinely shortens the label.
+
+## Tone and structure conventions
+
+- **Lead with positioning, not API coverage.** Browser-tests pages and
+  comparison pages start with a paragraph that names a real reader pain
+  point and how Smartest responds to it. Save API surface for later
+  sections.
+- **One Why per page.** If a page already has a Why-style intro at the top,
+  do not add a second `## Why ...` section in the body. The
+  Playwright-browser-tests page used to have both, and the second one
+  disoriented first-time readers.
+- **First-time-reader flow.** Browser-tests and Rails how-to pages should
+  flow Why → Quick Start (or comparable lead-in) → How it works → Reference,
+  in that order. Customization / advanced material lives at the end.
+- **Scenario titles for "how-to" pages, not technology names.** A page that
+  helps a reader test their local Rails app is titled
+  *"Test a Rails app locally"*, not *"Rails"*. The Browser Tests sidebar
+  entries follow this pattern.
+
+## Page-overlap warning: Test a Rails app locally vs vs Capybara
+
+`rails-browser-tests.md` (Test a Rails app locally) and
+`smartest-vs-capybara.md` (vs Capybara) discuss overlapping subject matter
+— Rails system tests, Capybara, Playwright, fixture-driven setup. Their
+roles are different and must stay different:
+
+- **Test a Rails app locally** is a *how-to*. The reader has already
+  decided to try Smartest on a Rails app and needs to scaffold, run, write,
+  and debug. The page may briefly motivate Smartest, but its bulk is
+  concrete Rails setup — fixtures, database cleanup, port settings,
+  troubleshooting.
+- **vs Capybara** is a *comparison*. The reader is deciding whether to
+  migrate. The page leads with the operational story (Capybara is great →
+  modern async pages are flaky → `with_playwright_page` is the awkward
+  escape hatch → Smartest replaces it cleanly → coexistence allows gradual
+  migration), then DSL side-by-side, then fit criteria.
+
+When editing one of these two, **read the other in the same change** and
+verify:
+
+1. The two pages do not say the same thing twice. The Rails how-to should
+   not become a comparison; the comparison should not become a how-to.
+2. Code examples that appear on both pages stay consistent (e.g. the
+   `suspended_user_page` fixture pattern).
+3. If a fact is updated (a generated file name, a default behavior, a
+   method name), the change is reflected on both pages.
+
+Prefer cross-links over duplication. The comparison page may link into
+specific sections of the Rails how-to; the how-to may link to the
+comparison when positioning Smartest against Capybara.
+
+## Verifying changes
+
+Before sending a docs PR:
+
+```bash
+cd documentation
+npm run build
+```
+
+The build fails on broken internal links (`onBrokenLinks: 'throw'`), so a
+clean build is a necessary baseline.
+
+For changes that affect navigation (sidebar structure, page titles,
+`sidebar_label`), also run `npm run serve` and check at minimum:
+
+- the renamed page's `<title>` tag in the browser
+- the sidebar label of the renamed page
+- the breadcrumb of the renamed page
+- the prev / next pager labels at the bottom of the renamed page

--- a/documentation/docs/fixtures.md
+++ b/documentation/docs/fixtures.md
@@ -1,5 +1,5 @@
 ---
-title: Pytest-style Fixtures in Ruby
+title: Fixtures
 description: Define class-based Smartest fixtures with keyword dependency injection and teardown.
 ---
 

--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -53,7 +53,7 @@ end
 - [Fixtures](./fixtures.md) explains class-based fixtures, dependencies, and teardown.
 - [Stubs](./stubs.md) shows method stubs that reset from fixture teardown.
 - [Helpers](./helpers.md) explains registering helper modules from `around_test`.
-- [Test a remote site](./playwright-browser-tests.md) shows how to drive Playwright browser tests against any URL.
+- [Why Smartest browser tests](./playwright-browser-tests.md) explains why pytest-style fixtures change Ruby browser testing, and walks through the Playwright-powered scaffold.
 - [Test a Rails app locally](./rails-browser-tests.md) shows the generated same-process Rails server fixture.
 
 ## Current Scope

--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -1,13 +1,13 @@
 ---
-title: Pytest-style fixtures for Ruby
+title: Why Smartest
 description: Smartest is a Ruby test runner with pytest-style fixture injection, explicit fixture dependencies, and teardown.
 ---
 
-# Smartest
+# Why Smartest
 
-introduces **Pytest-style fixtures for Ruby.**
+Smartest introduces **pytest-style fixtures for Ruby.**
 
-Smartest is a small Ruby test runner that brings pytest-style fixture
+It is a small Ruby test runner that brings pytest-style fixture
 injection, explicit fixture dependencies, and fixture teardown to Ruby tests.
 
 It is designed around three ideas:
@@ -49,11 +49,11 @@ end
 - [Getting Started](./getting-started.md) shows the smallest runnable test file.
 - [Writing Tests](./writing-tests.md) explains test structure and expectations.
 - [Skipping Tests](./skipping-tests.md) covers skipped tests and expected failures.
-- [Running Test Suites](./running-test-suites.md) covers autorun and the CLI.
+- [Running Tests](./running-test-suites.md) covers autorun and the CLI.
 - [Fixtures](./fixtures.md) explains class-based fixtures, dependencies, and teardown.
 - [Stubs](./stubs.md) shows method stubs that reset from fixture teardown.
 - [Helpers](./helpers.md) explains registering helper modules from `around_test`.
-- [Browser Tests With Playwright](./playwright-browser-tests.md) shows how to use fixtures for browser tests.
+- [Playwright Browser Tests](./playwright-browser-tests.md) shows how to use fixtures for browser tests.
 - [Rails Browser Tests](./rails-browser-tests.md) shows the generated same-process Rails server fixture.
 
 ## Current Scope

--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -53,8 +53,8 @@ end
 - [Fixtures](./fixtures.md) explains class-based fixtures, dependencies, and teardown.
 - [Stubs](./stubs.md) shows method stubs that reset from fixture teardown.
 - [Helpers](./helpers.md) explains registering helper modules from `around_test`.
-- [Playwright Browser Tests](./playwright-browser-tests.md) shows how to use fixtures for browser tests.
-- [Rails Browser Tests](./rails-browser-tests.md) shows the generated same-process Rails server fixture.
+- [Test a remote site](./playwright-browser-tests.md) shows how to drive Playwright browser tests against any URL.
+- [Test a Rails app locally](./rails-browser-tests.md) shows the generated same-process Rails server fixture.
 
 ## Current Scope
 

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -5,30 +5,14 @@ description: Why Smartest exists for Ruby browser testing, and how pytest-style 
 
 # Why Smartest browser tests
 
-Smartest exists to make Ruby browser testing **smarter**, not just slightly nicer.
+Smartest is invented to make Ruby browser testing **smarter**, not just slightly nicer.
 
 The direct inspiration is Playwright Test: its authors built a dedicated test runner instead of writing yet another Jest plugin, because browser testing is a different domain from unit testing — not just unit testing with a browser bolted on top. Smartest brings that same move to Ruby. Rather than plug Playwright into RSpec or Minitest, it rebuilds the runner around pytest-style fixtures so that the Playwright runtime, browser, and page lifecycles are expressed directly in each test's signature. See [Introducing pytest-style fixtures into Ruby for smarter browser testing](https://dev.to/yusukeiwaki/introducing-pytest-style-fixtures-into-ruby-for-smarter-browser-testing-lbi) for the longer story.
 
-Smartest can scaffold a Playwright-powered browser-test setup. Once it is in
-place, you can write browser tests that look and feel like ordinary Smartest
-tests — just receive a `page:` fixture and drive it with the Playwright API.
-
-## Why It Feels Like Playwright Test Fixtures
-
-Smartest is useful for Ruby browser testing when you want Playwright fixtures
-in Ruby without switching to Playwright Test's JavaScript or TypeScript runner.
-The generated `page:` fixture gives each test a Playwright `Page`, similar to
-the way Playwright Test provides a `page` fixture.
-
-Smartest is not API-compatible with Playwright Test. The similarity comes from
-Smartest's class-based fixture model:
-
-- `suite_fixture :playwright` starts the Playwright runtime once.
-- `suite_fixture :browser` shares the browser process across the suite.
-- `fixture :page` creates a fresh browser context and page per test.
-
-That makes Smartest a lightweight option for Rails Playwright tests or teams
-evaluating Capybara alternatives while keeping setup explicit in Ruby.
+In practice this means you stay in Ruby: each browser test receives a `page:`
+fixture and drives it with the full Playwright API. Smartest scaffolds the
+setup for you, and the four steps below take you from zero to a passing
+browser test.
 
 ## Quick Start
 
@@ -95,11 +79,11 @@ HEADLESS=0 SLOW_MO=250 bundle exec smartest smartest/example_browser_test.rb
 ```
 
 That's everything you need to start writing browser tests. The rest of this
-page is for when you want to change how the scaffold behaves.
+page explains what the scaffold generated and how to tune it.
 
 ---
 
-## Customization Points
+## How it works
 
 `smartest --init-browser` generates three Ruby files. They are ordinary
 Smartest fixtures and matchers — edit them freely to tune behavior.

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -1,9 +1,10 @@
 ---
-title: Playwright-style Browser Tests in Ruby
+title: Playwright Browser Tests
+sidebar_label: Playwright
 description: Use Smartest fixtures to drive Playwright browser tests in Ruby.
 ---
 
-# Playwright-style Browser Tests in Ruby
+# Playwright Browser Tests
 
 Smartest can scaffold a Playwright-powered browser-test setup. Once it is in
 place, you can write browser tests that look and feel like ordinary Smartest

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -7,7 +7,7 @@ description: Why Smartest exists for Ruby browser testing, and how pytest-style 
 
 Smartest exists to make Ruby browser testing **smarter**, not just slightly nicer.
 
-Mainstream Ruby browser tests still feel like a unit-test-era architecture with browser automation bolted on — RSpec or Minitest plus Capybara or Playwright, with setup scattered across `before` blocks, `let`, and support files. Smartest puts pytest-style fixtures first, so each test's dependencies live right in its signature, and the Playwright runtime, browser, and page lifecycles are expressed as fixtures directly. See [Introducing pytest-style fixtures into Ruby for smarter browser testing](https://dev.to/yusukeiwaki/introducing-pytest-style-fixtures-into-ruby-for-smarter-browser-testing-lbi) for the longer story.
+The direct inspiration is Playwright Test: its authors built a dedicated test runner instead of writing yet another Jest plugin, because browser testing is a different domain from unit testing — not just unit testing with a browser bolted on top. Smartest brings that same move to Ruby. Rather than plug Playwright into RSpec or Minitest, it rebuilds the runner around pytest-style fixtures so that the Playwright runtime, browser, and page lifecycles are expressed directly in each test's signature. See [Introducing pytest-style fixtures into Ruby for smarter browser testing](https://dev.to/yusukeiwaki/introducing-pytest-style-fixtures-into-ruby-for-smarter-browser-testing-lbi) for the longer story.
 
 Smartest can scaffold a Playwright-powered browser-test setup. Once it is in
 place, you can write browser tests that look and feel like ordinary Smartest

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -1,10 +1,9 @@
 ---
-title: Playwright Browser Tests
-sidebar_label: Playwright
-description: Use Smartest fixtures to drive Playwright browser tests in Ruby.
+title: Test a remote site
+description: Use Smartest fixtures to drive Playwright browser tests against any URL.
 ---
 
-# Playwright Browser Tests
+# Test a remote site
 
 Smartest can scaffold a Playwright-powered browser-test setup. Once it is in
 place, you can write browser tests that look and feel like ordinary Smartest

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -1,9 +1,13 @@
 ---
-title: Test a remote site
-description: Use Smartest fixtures to drive Playwright browser tests against any URL.
+title: Why Smartest browser tests
+description: Why Smartest exists for Ruby browser testing, and how pytest-style fixtures change the setup.
 ---
 
-# Test a remote site
+# Why Smartest browser tests
+
+Smartest exists to make Ruby browser testing **smarter**, not just slightly nicer.
+
+Mainstream Ruby browser tests still feel like a unit-test-era architecture with browser automation bolted on — RSpec or Minitest plus Capybara or Playwright, with setup scattered across `before` blocks, `let`, and support files. Smartest puts pytest-style fixtures first, so each test's dependencies live right in its signature, and the Playwright runtime, browser, and page lifecycles are expressed as fixtures directly. See [Introducing pytest-style fixtures into Ruby for smarter browser testing](https://dev.to/yusukeiwaki/introducing-pytest-style-fixtures-into-ruby-for-smarter-browser-testing-lbi) for the longer story.
 
 Smartest can scaffold a Playwright-powered browser-test setup. Once it is in
 place, you can write browser tests that look and feel like ordinary Smartest

--- a/documentation/docs/pytest-style-fixtures-for-ruby.md
+++ b/documentation/docs/pytest-style-fixtures-for-ruby.md
@@ -1,9 +1,10 @@
 ---
-title: Pytest-style Fixtures for Ruby
+title: Smartest vs Pytest
+sidebar_label: vs Pytest
 description: Map pytest fixture concepts to Smartest's class-based fixtures, keyword injection, fixture dependencies, and teardown.
 ---
 
-# Pytest-style Fixtures for Ruby
+# Smartest vs Pytest
 
 Smartest brings pytest-style fixture injection to Ruby without copying Python's
 decorator syntax.

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -1,10 +1,9 @@
 ---
-title: Rails Browser Tests
-sidebar_label: Rails
-description: Write Rails system tests with Playwright and explicit Smartest fixtures.
+title: Test a Rails app locally
+description: Write Rails system tests with Playwright and an in-process Rails server fixture.
 ---
 
-# Rails Browser Tests
+# Test a Rails app locally
 
 Smartest can run Rails browser tests against your Rails `test` environment.
 

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -1,16 +1,19 @@
 ---
 title: Test a Rails app locally
-description: Write Rails system tests with Playwright and an in-process Rails server fixture.
+description: A Capybara-independent Rails browser-test runner with Playwright and pytest-style fixtures. Coexists with existing Rails system tests for gradual migration.
 ---
 
 # Test a Rails app locally
 
-Smartest can run Rails browser tests against your Rails `test` environment.
-
-It is useful when you want the Rails-native power of system tests -- FactoryBot,
-ActiveRecord records, Rails helpers, mailers, jobs, method stubs, and local app
-state -- while writing browser interactions with Playwright locators and
-web-first assertions.
+Rails system tests are a wonderful idea: they make it straightforward to drive
+a real browser through any edge case in your app, using FactoryBot,
+ActiveRecord, and Rails helpers to shape the state from Ruby. But two
+operational problems show up over time — system tests run on Capybara, which
+is hard to customize beyond its defaults, and the architecture tends to
+produce flaky tests. Smartest replaces the runner with a Capybara-independent
+design built on Playwright and pytest-style fixtures. It coexists with your
+existing system tests, so you can migrate gradually instead of rewriting
+everything at once.
 
 ```bash
 bundle exec smartest --init-rails

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -1,5 +1,6 @@
 ---
 title: Rails Browser Tests
+sidebar_label: Rails
 description: Write Rails system tests with Playwright and explicit Smartest fixtures.
 ---
 

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -150,7 +150,7 @@ end
 ```
 
 ```ruby
-class ApplicationSystemFixture < Smartest::Fixture
+class ApplicationFixture < Smartest::Fixture
   fixture :suspended_user do
     create(:user, :suspended)
   end
@@ -170,7 +170,7 @@ Register the application-specific fixture:
 ```ruby
 around_suite do |suite|
   use_fixture RailsSystemTestFixture
-  use_fixture ApplicationSystemFixture
+  use_fixture ApplicationFixture
   use_matcher PlaywrightMatcher
   suite.run
 end
@@ -240,7 +240,7 @@ browser page are combined into a named page fixture.
 Stubs installed inside fixtures are automatically reset during fixture teardown.
 
 ```ruby
-class ApplicationSystemFixture < Smartest::Fixture
+class ApplicationFixture < Smartest::Fixture
   fixture :admin_user do
     create(:user, :admin)
   end

--- a/documentation/docs/running-test-suites.md
+++ b/documentation/docs/running-test-suites.md
@@ -1,9 +1,9 @@
 ---
-title: Running Test Suites
+title: Running Tests
 description: Run Smartest tests through autorun or the CLI.
 ---
 
-# Running Test Suites
+# Running Tests
 
 The primary Smartest workflow is:
 

--- a/documentation/docs/smartest-vs-capybara.md
+++ b/documentation/docs/smartest-vs-capybara.md
@@ -150,7 +150,7 @@ In Smartest the setup is a fixture and a stub, and the test declares the
 fixture it depends on:
 
 ```ruby title="Smartest"
-class ApplicationSystemFixture < Smartest::Fixture
+class ApplicationFixture < Smartest::Fixture
   fixture :suspended_user do
     create(:user, :suspended)
   end
@@ -201,7 +201,7 @@ smartest/
   test_helper.rb
   fixtures/
     rails_system_fixture.rb
-    application_system_fixture.rb
+    application_fixture.rb
   comment_submission_test.rb ← rewritten in Smartest
   push_failure_test.rb       ← rewritten in Smartest
 ```

--- a/documentation/docs/smartest-vs-capybara.md
+++ b/documentation/docs/smartest-vs-capybara.md
@@ -1,0 +1,211 @@
+---
+title: Smartest vs Capybara
+sidebar_label: vs Capybara
+description: Compare Capybara-driven Rails system tests with Smartest's Playwright + pytest-style fixture model. Keep Capybara for simple flows; migrate stability-critical tests to Smartest.
+---
+
+# Smartest vs Capybara
+
+Capybara is a brilliant pillar of Rails browser testing. One DSL — `visit`,
+`click_button`, `assert_selector` — covers a huge range of edge-case browser
+scenarios, and you can swap the underlying browser by changing the driver
+(Selenium, capybara-playwright-driver, and more).
+
+The friction shows up on async-heavy modern pages: SPAs, Turbo Streams, modal
+animations, "wait until the loading spinner disappears." Tests get flaky, and
+tuning Capybara waits to fix them becomes ongoing maintenance.
+
+The recommended escape hatch is `capybara-playwright-driver`'s
+`with_playwright_page`, which exposes a real Playwright `Page` and Playwright
+web-first assertions inside a block. As [a Zenn article on this pattern points
+out](https://zenn.dev/calldoctor_blog/articles/57e55c363343ff), that block
+adds a layer of complexity that feels disproportionate when all you wanted was
+a slightly more stable browser test.
+
+Smartest replaces the Capybara-based stack entirely. Thanks to pytest-style
+fixtures, writing `|page:|` is enough to get a Playwright `Page` already wired
+for browser testing — web-first assertions just work, with no wrapper to opt
+into. Because Smartest does not load `spec/` or `test/`, it coexists with your
+existing Capybara suite, so migration can be gradual rather than a rewrite.
+
+## At a Glance
+
+| Concern | Capybara | Smartest |
+| --- | --- | --- |
+| Browser API | DSL: `visit`, `fill_in`, `click_button`, `assert_selector` | Playwright: `page.goto`, `page.get_by_role`, `expect(page).to have_text` |
+| Wait strategy | Implicit Capybara waits, tunable with `using_wait_time` | Playwright web-first assertions retry until match |
+| Browser drivers | Swap drivers (Selenium, capybara-playwright-driver, …) | Direct Playwright via `playwright-ruby-client` |
+| Access to raw Playwright | `page.driver.with_playwright_page do \|p\| ... end` block | Just `page:` keyword fixture, always a Playwright `Page` |
+| Test setup | RSpec `let` / `before`, Minitest `setup` | Class-based fixtures requested by keyword |
+| Best fit | Simple synchronous flows | Async-heavy pages where stability and customization matter |
+
+## When Capybara still wins
+
+For a synchronous flow with no async surprises — a login form, a checkout that
+posts and redirects, a settings page that re-renders the whole document —
+Capybara is excellent and Smartest does not give you enough leverage to justify
+a rewrite.
+
+```ruby title="Capybara"
+scenario "a user logs in" do
+  visit new_session_path
+  fill_in "Email", with: "alice@example.com"
+  fill_in "Password", with: "secret"
+  click_button "Log in"
+
+  expect(page).to have_content("Welcome, Alice")
+end
+```
+
+This test is short, the DSL reads naturally, and there is little async timing
+for waits to get wrong. Keep it.
+
+## When Smartest pays off
+
+The case for migrating shows up when stability matters beyond Capybara's
+defaults — modal animations, network-driven content, Turbo Streams, SPA
+routing, push notifications, retried polls. Inside `capybara-playwright-driver`,
+the recommended response is to drop into a Playwright `Page` with
+`with_playwright_page`:
+
+```ruby title="Capybara + capybara-playwright-driver"
+scenario "the user sees the new comment after submission" do
+  visit post_path(post)
+
+  page.driver.with_playwright_page do |playwright_page|
+    playwright_page.locator("textarea[name='comment']").fill("Looks good")
+    playwright_page.locator("button[type='submit']").click
+    playwright_page.locator(".toast--success").wait_for(state: "visible")
+
+    expect(playwright_page.get_by_text("Looks good")).to be_visible
+  end
+end
+```
+
+This works, but the test now lives inside a nested callback. Some lines speak
+Capybara (`visit`, `page.driver`), others speak Playwright
+(`playwright_page....`), and you have to remember which side you are on.
+Window resize becomes
+`Capybara.current_session.driver.resize_window_to(...)`. Methods don't always
+map cleanly (`click_button` becomes `click_on`). Every test that needs
+stability acquires another layer of nesting.
+
+In Smartest the same scenario is written directly against a Playwright `Page`,
+with no `with_playwright_page` wrapper:
+
+```ruby title="Smartest"
+test("the user sees the new comment after submission") do |page:, post:|
+  page.goto(post_path(post))
+
+  page.locator("textarea[name='comment']").fill("Looks good")
+  page.locator("button[type='submit']").click
+
+  expect(page.locator(".toast--success")).to be_visible
+  expect(page.get_by_text("Looks good")).to be_visible
+end
+```
+
+`page` is a Playwright `Page`, supplied by the generated `RailsSystemTestFixture`
+(see [Test a Rails app locally](./rails-browser-tests.md)). Web-first
+assertions like `have_text` and `be_visible` retry until the page reaches the
+asserted state — which is exactly what auto-waiting gave you inside
+`with_playwright_page`, without the wrapper.
+
+## DSL Reference
+
+The browser API translates one-to-one between the two stacks:
+
+| Capybara | Smartest + Playwright |
+| --- | --- |
+| `visit root_path` | `page.goto("/")` |
+| `fill_in "Email", with: user.email` | `page.get_by_label("Email").fill(user.email)` |
+| `click_button "Log in"` | `page.get_by_role("button", name: "Log in").click` |
+| `click_link "Profile"` | `page.get_by_role("link", name: "Profile").click` |
+| `assert_text "Dashboard"` | `expect(page.get_by_text("Dashboard")).to be_visible` |
+| `assert_selector "h1", text: "Users"` | `expect(page.locator("h1")).to have_text("Users")` |
+| `assert_no_text "Error"` | `expect(page.get_by_text("Error")).not_to be_visible` |
+| `assert_current_path "/dashboard"` | `expect(page).to have_url(/\/dashboard\z/)` |
+| `using_wait_time(10) { ... }` | Web-first assertions auto-retry; tune the Playwright `expect` timeout |
+| `Capybara.current_session.driver.resize_window_to(1280, 800)` | `page.set_viewport_size(width: 1280, height: 800)` |
+
+## Test setup and stubbing
+
+Capybara tests typically share state through RSpec `let` / `before`:
+
+```ruby title="Capybara + RSpec"
+let(:suspended_user) { create(:user, :suspended) }
+
+before do
+  allow_any_instance_of(ApplicationController)
+    .to receive(:current_user)
+    .and_return(suspended_user)
+end
+
+scenario "suspended user sees account restriction page" do
+  visit dashboard_path
+  expect(page).to have_content("Your account is suspended")
+end
+```
+
+In Smartest the setup is a fixture and a stub, and the test declares the
+fixture it depends on:
+
+```ruby title="Smartest"
+class ApplicationSystemFixture < Smartest::Fixture
+  fixture :suspended_user do
+    create(:user, :suspended)
+  end
+
+  fixture :suspended_user_page do |page:, suspended_user:|
+    simple_stub_any_instance_of(ApplicationController, :current_user) do
+      suspended_user
+    end
+    page
+  end
+end
+
+test("suspended user sees account restriction page") do |suspended_user_page:|
+  suspended_user_page.goto("/dashboard")
+  expect(suspended_user_page.get_by_text("Your account is suspended")).to be_visible
+end
+```
+
+The dependency is visible at the test boundary, and Smartest resets the stub
+during fixture teardown.
+
+## When Smartest is a good fit
+
+Smartest is worth considering when:
+
+- existing system tests are flaky on async-heavy pages and Capybara waits are hard to tune
+- you already reach for `with_playwright_page` in many tests
+- you want Playwright web-first assertions to be the default, not a wrapper
+- setup dependencies should be visible at the test boundary
+
+Capybara may stay the better fit when:
+
+- tests are short, synchronous flows where the DSL reads naturally
+- the team prefers `visit` / `fill_in` / `assert_selector` and is not hitting flakiness
+- the suite leans on Capybara-specific helpers, drivers, or matchers you do not want to replace
+
+## Moving One Test at a Time
+
+Smartest does not load `spec/` or `test/`, so Capybara-based system tests stay
+where they are. Add Smartest tests under `smartest/`, and start by moving just
+the tests that hurt:
+
+```text
+spec/system/
+  login_spec.rb              ← stays in Capybara
+  dashboard_spec.rb          ← stays in Capybara
+smartest/
+  test_helper.rb
+  fixtures/
+    rails_system_fixture.rb
+    application_system_fixture.rb
+  comment_submission_test.rb ← rewritten in Smartest
+  push_failure_test.rb       ← rewritten in Smartest
+```
+
+Move the most fragile tests first. The login flow can stay in Capybara
+indefinitely.

--- a/documentation/docs/smartest-vs-capybara.md
+++ b/documentation/docs/smartest-vs-capybara.md
@@ -17,10 +17,9 @@ tuning Capybara waits to fix them becomes ongoing maintenance.
 
 The recommended escape hatch is `capybara-playwright-driver`'s
 `with_playwright_page`, which exposes a real Playwright `Page` and Playwright
-web-first assertions inside a block. As [a Zenn article on this pattern points
-out](https://zenn.dev/calldoctor_blog/articles/57e55c363343ff), that block
-adds a layer of complexity that feels disproportionate when all you wanted was
-a slightly more stable browser test.
+web-first assertions inside a block. That block solves the stability problem,
+but the resulting nested-callback style feels disproportionate when all you
+wanted was a slightly more stable browser test.
 
 Smartest replaces the Capybara-based stack entirely. Thanks to pytest-style
 fixtures, writing `|page:|` is enough to get a Playwright `Page` already wired

--- a/documentation/docs/smartest-vs-minitest.md
+++ b/documentation/docs/smartest-vs-minitest.md
@@ -1,5 +1,6 @@
 ---
 title: Smartest vs Minitest
+sidebar_label: vs Minitest
 description: Compare Smartest's keyword fixture injection with Minitest setup, teardown, assertions, and test file layout.
 ---
 

--- a/documentation/docs/smartest-vs-rspec.md
+++ b/documentation/docs/smartest-vs-rspec.md
@@ -1,5 +1,6 @@
 ---
 title: Smartest vs RSpec
+sidebar_label: vs RSpec
 description: Compare Smartest's explicit keyword fixture injection with RSpec let, before hooks, examples, and teardown.
 ---
 

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -42,6 +42,7 @@ const sidebars = {
         'pytest-style-fixtures-for-ruby',
         'smartest-vs-rspec',
         'smartest-vs-minitest',
+        'smartest-vs-capybara',
       ],
     },
     {

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -3,17 +3,32 @@
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   docs: [
-    'intro',
-    'getting-started',
-    'writing-tests',
-    'running-test-suites',
-    'skipping-tests',
-    'fixtures',
-    'stubs',
-    'matchers',
-    'helpers',
-    'playwright-browser-tests',
-    'rails-browser-tests',
+    {
+      type: 'category',
+      label: 'Introduction',
+      collapsed: false,
+      items: ['intro', 'getting-started'],
+    },
+    {
+      type: 'category',
+      label: 'Learn',
+      collapsed: false,
+      items: [
+        'writing-tests',
+        'fixtures',
+        'stubs',
+        'matchers',
+        'helpers',
+        'skipping-tests',
+        'running-test-suites',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Browser Tests',
+      collapsed: false,
+      items: ['playwright-browser-tests', 'rails-browser-tests'],
+    },
     {
       type: 'category',
       label: 'Comparisons',


### PR DESCRIPTION
## Summary

- Group the flat docs sidebar into **Introduction / Learn / Browser Tests / Comparisons / Reference** categories, modeled after the [Vitest guide](https://vitest.dev/guide/).
- Drop SEO-stuffed titles so each page's `<title>`, `<h1>`, and sidebar entry match (e.g. `Pytest-style Fixtures in Ruby` → `Fixtures`). Search keywords stay in the `description` frontmatter, which Docusaurus renders as `<meta name="description">`.
- Use `sidebar_label` only where the sidebar entry should be shorter than the page title (Playwright, Rails, vs Pytest, vs RSpec, vs Minitest).
- Fix the broken first sentence in `intro.md` after renaming the H1 (`Smartest` → `Why Smartest`).

### Sidebar before / after

```
Before                                    After
---------------------------------------   -------------------------------
Pytest-style fixtures for Ruby            Introduction
Getting Started                             Why Smartest
Writing Tests                               Getting Started
Running Test Suites                       Learn
Skipping Tests                              Writing Tests
Pytest-style Fixtures in Ruby               Fixtures
Stubs                                       Stubs
Matchers                                    Matchers
Helpers                                     Helpers
Playwright-style Browser Tests in Ruby      Skipping Tests
Rails Browser Tests                         Running Tests
Comparisons                               Browser Tests
  Pytest-style Fixtures for Ruby            Playwright
  Smartest vs RSpec                         Rails
  Smartest vs Minitest                    Comparisons
Reference                                   vs Pytest
  Errors                                    vs RSpec
                                            vs Minitest
                                          Reference
                                            Errors
```

## Test plan

- [x] `npm run build` passes in `documentation/`
- [x] Local `npm run serve` verified via Playwright: page `<title>` is `Fixtures | Smartest`, sidebar shows the new category structure, breadcrumb is `Home > Learn > Fixtures`, prev/next nav uses the new labels
- [ ] Vercel preview renders the same on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)