### PR TITLE
[codex] Fix Rails Docker scaffold friction

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,15 @@ smartest/matchers/playwright_matcher.rb
 smartest/example_rails_system_test.rb
 ```
 
-The generated fixture requires `smartest/rails` and starts
+The generated fixture requires `smartest/rails`, loads `config/environment`
+when `test_helper` requires the fixture file, and starts
 `Smartest::Rails::TestServer` against `Rails.application` in the same Ruby
-process as the test runner. `Smartest::Rails::TestServer` is only loaded by
-explicitly requiring `smartest/rails`; plain `require "smartest"` does not load
-Puma.
+process as the test runner. Loading Rails during helper setup makes app
+constants such as ActiveRecord models available inside test files and
+`around_test` hooks before per-test fixtures are resolved. The generated
+fixture forces `RAILS_ENV` and `RACK_ENV` to `test` before Rails boots.
+`Smartest::Rails::TestServer` is only loaded by explicitly requiring
+`smartest/rails`; plain `require "smartest"` does not load Puma.
 
 This is aimed at local Rails system tests that combine Rails test data, stubs,
 and Playwright browser assertions. It is not a Capybara compatibility layer or
@@ -282,7 +286,13 @@ SMARTEST_SKIP_BROWSER_DOWNLOAD=1 bundle exec smartest --init-rails
 At runtime, set `PLAYWRIGHT_WS_ENDPOINT`,
 `SMARTEST_RAILS_TEST_SERVER_HOST`, `SMARTEST_RAILS_TEST_SERVER_PORT`, and
 `SMARTEST_RAILS_BASE_URL` so the generated fixture connects to the Playwright
-sidecar and gives the browser a Docker-network URL for Rails.
+sidecar and gives the browser a Docker-network URL for Rails. These are usually
+stable Docker topology settings, so put them in `compose.yml` instead of
+repeating them on every `docker compose run` command.
+For a Rails Compose service named `web`, use
+`SMARTEST_RAILS_BASE_URL=http://web:4001`; replace `web` with your service name.
+The generated Rails fixture sets `RAILS_ENV` and `RACK_ENV` to `test`, even if
+the same service normally runs in development.
 
 Run the generated Rails browser example with:
 

--- a/documentation/docs/rails-browser-tests-with-docker.md
+++ b/documentation/docs/rails-browser-tests-with-docker.md
@@ -24,18 +24,23 @@ execution, and troubleshooting — see
 
 ## Prerequisites
 
+The examples on this page use `web` as the Rails Compose service name. If your
+project uses a different service name, replace `web` in the commands and in
+`SMARTEST_RAILS_BASE_URL`.
+
 Add Smartest to the test group in the Rails app's `Gemfile` and rebuild the
 image so the gem is available inside the app container:
 
 ```bash
-bundle add smartest --group test
+docker compose run --rm web bundle add smartest --group test
+docker compose build web
 ```
 
 Prepare the test database. From your host shell, run it through Compose so it
 uses the same image and database service as the test run:
 
 ```bash
-docker compose run --rm app bin/rails db:test:prepare
+docker compose run --rm web bin/rails db:test:prepare
 ```
 
 ## Quick start
@@ -44,23 +49,29 @@ Generate the Rails browser-test scaffold without downloading browser binaries
 into the Rails app container:
 
 ```bash
-SMARTEST_SKIP_BROWSER_DOWNLOAD=1 bundle exec smartest --init-rails
+docker compose run --rm -e SMARTEST_SKIP_BROWSER_DOWNLOAD=1 \
+  web bundle exec smartest --init-rails
 ```
 
 This still creates the Rails fixture, Playwright matcher, example test, Gemfile
 entry, and Playwright npm package. It skips only
 `./node_modules/.bin/playwright install`.
 
-Run the suite with a Playwright server URL and a Rails URL that the browser can
-reach from the Docker network:
+Put the Docker network wiring variables in Compose, as shown in the example
+below. Then run the suite:
 
 ```bash
-PLAYWRIGHT_WS_ENDPOINT=ws://playwright:8888/ws \
-SMARTEST_RAILS_TEST_SERVER_HOST=0.0.0.0 \
-SMARTEST_RAILS_TEST_SERVER_PORT=4001 \
-SMARTEST_RAILS_BASE_URL=http://app:4001 \
-bundle exec smartest smartest/
+docker compose run --rm --use-aliases \
+  web bundle exec smartest smartest/
 ```
+
+`--use-aliases` makes the one-off test container join the Compose network under
+the `web` service name, so the Playwright sidecar can resolve
+`http://web:4001`.
+
+The generated Rails fixture forces `RAILS_ENV` and `RACK_ENV` to `test` before
+loading `config/environment`, so the test run does not depend on the service's
+development environment variables.
 
 There is no separate `--browser=docker` or `--skip-browser-install` option. The
 same generated fixture supports local and Docker runs through environment
@@ -68,7 +79,7 @@ variables.
 
 ## Architecture
 
-![Two Docker Compose services. In the Rails app container (Alpine + Ruby + Node.js), the Smartest test runner boots Smartest::Rails::TestServer — which carries Rails.application bound to 0.0.0.0:3000 — and drives playwright-ruby-client. In the Playwright sidecar container (mcr.microsoft.com/playwright), PlaywrightServer drives Chromium, Firefox, and WebKit. The test runner reaches the browser over WebSocket (ws://playwright:8888/ws), and the browser reaches the Rails test server over HTTP (http://app:3000).](/img/rails-docker-architecture.png)
+![Two Docker Compose services. In the Rails web container (Alpine + Ruby + Node.js), the Smartest test runner boots Smartest::Rails::TestServer — which carries Rails.application bound to 0.0.0.0:3000 — and drives playwright-ruby-client. In the Playwright sidecar container (mcr.microsoft.com/playwright), PlaywrightServer drives Chromium, Firefox, and WebKit. The test runner reaches the browser over WebSocket (ws://playwright:8888/ws), and the browser reaches the Rails test server over HTTP (http://web:3000).](/img/rails-docker-architecture.png)
 
 In the Rails app container:
 
@@ -91,44 +102,45 @@ in another Compose service nor in the same container. Smartest fixtures
 install method stubs in the test runner process, and those stubs are only
 visible to the Rails server thread when both run in the same Ruby process.
 
-In the Compose example below, the `app` service runs `bundle exec smartest`,
-which boots Rails inside that test runner. Do not add a second service that
-runs `bin/rails server -e test` against the same database.
+The one-off `docker compose run web bundle exec smartest ...` command boots
+Rails inside that test runner. Do not add a second service that runs
+`bin/rails server -e test` against the same database.
 
 :::
 
 ## Docker Compose example
 
-```yaml title="compose.yml"
-services:
-  app:
-    build: .
-    command: bundle exec smartest smartest/
-    environment:
-      RAILS_ENV: test
-      RACK_ENV: test
+Add the Playwright sidecar and the Smartest browser-test environment variables
+to your existing Rails service. This is a diff against your current Compose
+file, not a replacement file. Keep the service's normal development `command`
+and `RAILS_ENV` unchanged if this file is also used for `docker compose up`.
 
-      PLAYWRIGHT_WS_ENDPOINT: ws://playwright:8888/ws
-      SMARTEST_RAILS_TEST_SERVER_HOST: 0.0.0.0
-      SMARTEST_RAILS_TEST_SERVER_PORT: 4001
-      SMARTEST_RAILS_BASE_URL: http://app:4001
-
-      BROWSER: chromium
-      HEADLESS: "true"
-    depends_on:
-      - playwright
-
-  playwright:
-    image: mcr.microsoft.com/playwright:v1.59.0-noble
-    init: true
-    ipc: host
-    working_dir: /home/pwuser
-    user: pwuser
-    command: >
-      /bin/sh -c "npx -y playwright@1.59.0 run-server --port 8888 --host 0.0.0.0 --path /ws"
+```diff title="compose.yml"
+ services:
+   web:
+     build: .
++    environment:
++      PLAYWRIGHT_WS_ENDPOINT: ws://playwright:8888/ws
++      SMARTEST_RAILS_TEST_SERVER_HOST: 0.0.0.0
++      SMARTEST_RAILS_TEST_SERVER_PORT: 4001
++      SMARTEST_RAILS_BASE_URL: http://web:4001
++
++      BROWSER: chromium
++      HEADLESS: "true"
++    depends_on:
++      - playwright
++
++  playwright:
++    image: mcr.microsoft.com/playwright:v1.59.0-noble
++    init: true
++    ipc: host
++    working_dir: /home/pwuser
++    user: pwuser
++    command: >
++      /bin/sh -c "npx -y playwright@1.59.0 run-server --port 8888 --host 0.0.0.0 --path /ws"
 ```
 
-Use your own service name if it is not `app`; `SMARTEST_RAILS_BASE_URL` must use
+Use your own service name if it is not `web`; `SMARTEST_RAILS_BASE_URL` must use
 the host name that the Playwright container can resolve on the Compose network.
 
 ## Environment variables
@@ -147,6 +159,10 @@ the host name that the Playwright container can resolve on the Compose network.
 separate. The first affects scaffold initialization; the second chooses remote
 Playwright at test runtime.
 
+For Docker sidecar runs, keep `PLAYWRIGHT_WS_ENDPOINT` and the
+`SMARTEST_RAILS_*` network variables in Compose. The generated Rails fixture
+sets `RAILS_ENV` and `RACK_ENV` to `test` before Rails boots.
+
 ## Base URL for the Playwright sidecar
 
 In local mode, `127.0.0.1` points at the machine running both Rails and the
@@ -161,11 +177,11 @@ Use all three Rails server variables together:
 ```bash
 SMARTEST_RAILS_TEST_SERVER_HOST=0.0.0.0
 SMARTEST_RAILS_TEST_SERVER_PORT=4001
-SMARTEST_RAILS_BASE_URL=http://app:4001
+SMARTEST_RAILS_BASE_URL=http://web:4001
 ```
 
 The generated fixture binds Rails to `0.0.0.0`, waits for readiness from inside
-the app container, and gives Playwright `http://app:4001` as the browser-visible
+the app container, and gives Playwright `http://web:4001` as the browser-visible
 base URL.
 
 ## Version matching
@@ -173,11 +189,17 @@ base URL.
 Keep the Playwright server version in the sidecar aligned with the version
 expected by `playwright-ruby-client` in the Rails app container.
 
-After bundle install, you can print the expected Playwright version with:
+After bundle install, you can print the expected Playwright version from the
+Rails app container with:
 
 ```bash
-ruby -rplaywright -e 'puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION'
+docker compose run --rm -e BUNDLE_WITHOUT="" web \
+  bundle exec ruby -rplaywright -e 'puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION'
 ```
+
+The `BUNDLE_WITHOUT=""` override matters when your image excludes the test group
+by default; `playwright-ruby-client` is installed in the test group by the Rails
+scaffold.
 
 Use that version in both the Docker image tag and the `npx playwright@...`
 command when possible.

--- a/documentation/docs/rails-browser-tests-with-docker.md
+++ b/documentation/docs/rails-browser-tests-with-docker.md
@@ -36,12 +36,17 @@ docker compose run --rm web bundle add smartest --group test
 docker compose build web
 ```
 
-Prepare the test database. From your host shell, run it through Compose so it
-uses the same image and database service as the test run:
+Prepare the Rails databases. From your host shell, run the commands through
+Compose so they use the same image and database service as the test run:
 
 ```bash
+docker compose run --rm web bin/rails db:prepare
 docker compose run --rm web bin/rails db:test:prepare
 ```
+
+On a fresh Rails app, `db:prepare` creates and migrates the app database first,
+which also writes `db/schema.rb` or `db/structure.sql`. Then `db:test:prepare`
+can load that schema into the test database.
 
 ## Quick start
 

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -17,6 +17,7 @@ everything at once.
 
 ```bash
 bundle exec smartest --init-rails
+bin/rails db:prepare
 bin/rails db:test:prepare
 bundle exec smartest smartest/example_rails_system_test.rb
 ```
@@ -93,11 +94,16 @@ sidecar container, initialize with `SMARTEST_SKIP_BROWSER_DOWNLOAD=1` instead.
 See [Test a Rails app with Docker](./rails-browser-tests-with-docker.md) for the
 sidecar setup.
 
-Prepare the Rails test database:
+Prepare the Rails databases:
 
 ```bash
+bin/rails db:prepare
 bin/rails db:test:prepare
 ```
+
+On a fresh Rails app, `db:prepare` creates and migrates the app database first,
+which also writes `db/schema.rb` or `db/structure.sql`. Then `db:test:prepare`
+can load that schema into the test database.
 
 Run the generated example:
 
@@ -521,9 +527,10 @@ Do not rely on method-stub isolation for multi-threaded parallel test execution.
 
 ## Database setup and cleanup
 
-Prepare the test database before running Smartest:
+Prepare the databases before running Smartest:
 
 ```bash
+bin/rails db:prepare
 bin/rails db:test:prepare
 bundle exec smartest smartest/example_rails_system_test.rb
 ```

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -341,13 +341,12 @@ The generated Rails fixture starts `Rails.application` with
 require "smartest/rails"
 require "playwright"
 
+ENV["RAILS_ENV"] = "test"
+ENV["RACK_ENV"] = "test"
+require_relative "../../config/environment"
+
 class RailsSystemTestFixture < Smartest::Fixture
   suite_fixture :rails_server do
-    ENV["RAILS_ENV"] ||= "test"
-    ENV["RACK_ENV"] ||= ENV["RAILS_ENV"]
-
-    require_relative "../../config/environment"
-
     server = Smartest::Rails::TestServer.new(
       app: Rails.application,
       host: ENV["SMARTEST_RAILS_TEST_SERVER_HOST"],
@@ -423,6 +422,11 @@ end
 `Smartest::Rails::TestServer` is loaded only when `smartest/rails` is required.
 Plain `require "smartest"` does not load Puma.
 
+The generated fixture forces `RAILS_ENV` and `RACK_ENV` to `test`, then loads
+`config/environment` when `test_helper` requires the fixture file. That makes
+Rails constants such as ActiveRecord models available inside test files and
+`around_test` hooks before per-test fixtures are resolved.
+
 The generated fixture keeps expensive resources suite-scoped:
 
 - `rails_server`
@@ -481,7 +485,7 @@ tools that expect a stable local port.
 Set `SMARTEST_RAILS_TEST_SERVER_HOST` only when the Rails test server must bind
 to another interface. For example, Docker sidecar runs usually need
 `SMARTEST_RAILS_TEST_SERVER_HOST=0.0.0.0` plus
-`SMARTEST_RAILS_BASE_URL=http://app:4001`; see
+`SMARTEST_RAILS_BASE_URL=http://web:4001`; see
 [Test a Rails app with Docker](./rails-browser-tests-with-docker.md).
 
 ## Method stubs
@@ -581,11 +585,12 @@ separation or method-stub isolation between parallel workers.
 
 Make sure `RAILS_ENV` is set before `config/environment` is loaded.
 
-The generated fixture does this before requiring the Rails app:
+The generated fixture forces the Rails and Rack environments to `test` while
+`test_helper` is loading fixture files:
 
 ```ruby
-ENV["RAILS_ENV"] ||= "test"
-ENV["RACK_ENV"] ||= ENV["RAILS_ENV"]
+ENV["RAILS_ENV"] = "test"
+ENV["RACK_ENV"] = "test"
 
 require_relative "../../config/environment"
 ```

--- a/lib/smartest/init_browser_generator.rb
+++ b/lib/smartest/init_browser_generator.rb
@@ -160,11 +160,15 @@ module Smartest
     end
 
     def install_dependencies
-      install_commands.each do |command|
-        @output.puts "run     #{command.join(" ")}"
-        next if @command_runner.call(command, chdir: @root)
+      commands = install_commands
 
-        raise "command failed: #{command.join(" ")}"
+      with_unbundled_env do
+        commands.each do |command|
+          @output.puts "run     #{command.join(" ")}"
+          next if @command_runner.call(command, chdir: @root)
+
+          raise "command failed: #{command.join(" ")}"
+        end
       end
     end
 
@@ -178,6 +182,16 @@ module Smartest
 
     def run_system_command(command, chdir:)
       system(*command, chdir: chdir)
+    end
+
+    def with_unbundled_env(&block)
+      require "bundler"
+
+      if Bundler.respond_to?(:with_unbundled_env)
+        Bundler.with_unbundled_env(&block)
+      else
+        Bundler.with_clean_env(&block)
+      end
     end
   end
 end

--- a/lib/smartest/init_rails_generator.rb
+++ b/lib/smartest/init_rails_generator.rb
@@ -10,14 +10,14 @@ module Smartest
       require 'smartest/rails'
       require "playwright"
 
+      # Force the test environment and load Rails while test_helper is required
+      # so app constants are available before per-test fixtures are resolved.
+      ENV["RAILS_ENV"] = "test"
+      ENV["RACK_ENV"] = "test"
+      require_relative "../../config/environment"
+
       class RailsSystemTestFixture < Smartest::Fixture
         suite_fixture :rails_server do
-          # Set the environment before loading config/environment so the test
-          # server cannot boot against the development database by default.
-          ENV["RAILS_ENV"] ||= "test"
-          ENV["RACK_ENV"] ||= ENV["RAILS_ENV"]
-          require_relative "../../config/environment"
-
           server = Smartest::Rails::TestServer.new(
             app: Rails.application,
             host: ENV["SMARTEST_RAILS_TEST_SERVER_HOST"],
@@ -211,11 +211,15 @@ module Smartest
     end
 
     def install_dependencies
-      install_commands.each do |command|
-        @output.puts "run     #{command.join(" ")}"
-        next if @command_runner.call(command, chdir: @root)
+      commands = install_commands
 
-        raise "command failed: #{command.join(" ")}"
+      with_unbundled_env do
+        commands.each do |command|
+          @output.puts "run     #{command.join(" ")}"
+          next if @command_runner.call(command, chdir: @root)
+
+          raise "command failed: #{command.join(" ")}"
+        end
       end
 
       if skip_browser_download?
@@ -237,6 +241,16 @@ module Smartest
 
     def run_system_command(command, chdir:)
       system(*command, chdir: chdir)
+    end
+
+    def with_unbundled_env(&block)
+      require "bundler"
+
+      if Bundler.respond_to?(:with_unbundled_env)
+        Bundler.with_unbundled_env(&block)
+      else
+        Bundler.with_clean_env(&block)
+      end
     end
   end
 end

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -2183,6 +2183,49 @@ test("cli browser init generator creates Playwright scaffold and installation co
   end
 end
 
+test("cli browser init generator runs installation commands outside the current Bundler environment") do
+  require "bundler"
+
+  Dir.mktmpdir do |dir|
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "smartest"
+    RUBY
+
+    command_environments = []
+    output = StringIO.new
+    generator = Smartest::InitBrowserGenerator.new(
+      root: dir,
+      output: output,
+      command_runner: ->(_command, chdir:) {
+        command_environments << {
+          bundle_gemfile: ENV["BUNDLE_GEMFILE"],
+          bundle_bin_path: ENV["BUNDLE_BIN_PATH"],
+          rubyopt: ENV["RUBYOPT"]
+        }
+        true
+      }
+    )
+
+    SmartestSelfTest.with_env(
+      "BUNDLE_GEMFILE" => File.join(dir, "Gemfile"),
+      "BUNDLE_BIN_PATH" => "/tmp/smartest-self-test-bundle",
+      "RUBYOPT" => "-rbundler/setup -W0"
+    ) do
+      status = generator.run
+      expect(status).to eq(0)
+    end
+
+    expect(command_environments.length).to eq(4)
+    expect(command_environments.all? do |environment|
+      environment[:bundle_gemfile].nil? &&
+        environment[:bundle_bin_path].nil? &&
+        !environment[:rubyopt].to_s.include?("bundler/setup")
+    end).to eq(true)
+  end
+end
+
 test("cli browser init generator skips npm init when package.json already exists") do
   Dir.mktmpdir do |dir|
     File.write(File.join(dir, "Gemfile"), <<~RUBY)
@@ -2341,8 +2384,12 @@ test("cli rails init generator creates Rails browser scaffold and installation c
     expect(rails_fixture).to include("require 'smartest/rails'")
     expect(rails_fixture).to include("class RailsSystemTestFixture < Smartest::Fixture")
     expect(rails_fixture).to include("suite_fixture :rails_server")
-    expect(rails_fixture).to include("server cannot boot against the development database")
+    expect(rails_fixture).to include('ENV["RAILS_ENV"] = "test"')
+    expect(rails_fixture).to include('ENV["RACK_ENV"] = "test"')
+    expect(rails_fixture).not_to include('ENV["RAILS_ENV"] ||=')
+    expect(rails_fixture).to include("constants are available before per-test fixtures are resolved")
     expect(rails_fixture).to include('require_relative "../../config/environment"')
+    expect(rails_fixture.index('require_relative "../../config/environment"') < rails_fixture.index("class RailsSystemTestFixture")).to eq(true)
     expect(rails_fixture).to include("Smartest::Rails::TestServer.new(")
     expect(rails_fixture).to include('host: ENV["SMARTEST_RAILS_TEST_SERVER_HOST"]')
     expect(rails_fixture).not_to include("bind_host:")
@@ -2395,6 +2442,112 @@ test("cli rails init generator creates Rails browser scaffold and installation c
       ]
     )
     expect(output.string).to include("Run your Rails browser test suite with: bundle exec smartest smartest/example_rails_system_test.rb")
+  end
+end
+
+test("cli rails init generator forces Rails test environment when the generated fixture is required") do
+  Dir.mktmpdir do |dir|
+    FileUtils.mkdir_p(File.join(dir, "config"))
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "rails"
+      gem "smartest"
+    RUBY
+    File.write(File.join(dir, "config/environment.rb"), <<~RUBY)
+      raise "RAILS_ENV was not set before loading Rails" unless ENV["RAILS_ENV"] == "test"
+      raise "RACK_ENV was not set before loading Rails" unless ENV["RACK_ENV"] == "test"
+
+      class User
+      end
+    RUBY
+
+    stub_dir = File.join(dir, "stub_load_path")
+    FileUtils.mkdir_p(File.join(stub_dir, "smartest"))
+    File.write(File.join(stub_dir, "smartest/rails.rb"), <<~RUBY)
+      module Smartest
+        class Fixture
+          def self.suite_fixture(*)
+          end
+
+          def self.fixture(*)
+          end
+        end
+
+        module Rails
+        end
+      end
+    RUBY
+    File.write(File.join(stub_dir, "playwright.rb"), "")
+
+    generator = Smartest::InitRailsGenerator.new(
+      root: dir,
+      output: StringIO.new,
+      command_runner: ->(_command, chdir:) { true }
+    )
+    generator.run
+
+    stdout, stderr, status = Open3.capture3(
+      {
+        "RUBYLIB" => stub_dir,
+        "RAILS_ENV" => "development",
+        "RACK_ENV" => "development"
+      },
+      "ruby",
+      "-e",
+      <<~RUBY
+        require #{File.join(dir, "smartest/fixtures/rails_system_fixture").inspect}
+        puts User.name
+      RUBY
+    )
+
+    expect(status.success?).to eq(true)
+    expect(stderr).to eq("")
+    expect(stdout).to eq("User\n")
+  end
+end
+
+test("cli rails init generator runs installation commands outside the current Bundler environment") do
+  require "bundler"
+
+  Dir.mktmpdir do |dir|
+    File.write(File.join(dir, "Gemfile"), <<~RUBY)
+      source "https://rubygems.org"
+
+      gem "rails"
+      gem "smartest"
+    RUBY
+
+    command_environments = []
+    output = StringIO.new
+    generator = Smartest::InitRailsGenerator.new(
+      root: dir,
+      output: output,
+      command_runner: ->(_command, chdir:) {
+        command_environments << {
+          bundle_gemfile: ENV["BUNDLE_GEMFILE"],
+          bundle_bin_path: ENV["BUNDLE_BIN_PATH"],
+          rubyopt: ENV["RUBYOPT"]
+        }
+        true
+      }
+    )
+
+    SmartestSelfTest.with_env(
+      "BUNDLE_GEMFILE" => File.join(dir, "Gemfile"),
+      "BUNDLE_BIN_PATH" => "/tmp/smartest-self-test-bundle",
+      "RUBYOPT" => "-rbundler/setup -W0"
+    ) do
+      status = generator.run
+      expect(status).to eq(0)
+    end
+
+    expect(command_environments.length).to eq(4)
+    expect(command_environments.all? do |environment|
+      environment[:bundle_gemfile].nil? &&
+        environment[:bundle_bin_path].nil? &&
+        !environment[:rubyopt].to_s.include?("bundler/setup")
+    end).to eq(true)
   end
 end
 


### PR DESCRIPTION
## Summary

Fixes the Rails browser-test scaffold and Docker documentation friction reported in #43.

- Run generator dependency installs outside the current Bundler environment so `bundle exec smartest --init-rails` can update the app bundle safely.
- Load Rails when the generated Rails fixture is required, and force `RAILS_ENV` / `RACK_ENV` to `test` before `config/environment` loads.
- Update Rails Docker docs to use a `web` service, keep Docker network variables in Compose, show the Compose example as a diff, document `--use-aliases`, and use `bundle exec` for the Playwright version check.
- Apply the same unbundled dependency install behavior to the browser init generator because it has the same failure mode.

## Validation

- `bundle exec ruby smartest/smartest_test.rb`
- `bundle exec rake test`
- `npm run build` from `documentation/`
- `git diff --check`

## Notes

Untracked local files were left out of this branch.