### PR TITLE
[codex] Rename Rails test server to Rack

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,15 +259,17 @@ smartest/matchers/playwright_matcher.rb
 smartest/example_rails_system_test.rb
 ```
 
-The generated fixture requires `smartest/rails`, loads `config/environment`
+The generated fixture requires `smartest/rack`, loads `config/environment`
 when `test_helper` requires the fixture file, and starts
-`Smartest::Rails::TestServer` against `Rails.application` in the same Ruby
+`Smartest::Rack::TestServer` against `Rails.application` in the same Ruby
 process as the test runner. Loading Rails during helper setup makes app
 constants such as ActiveRecord models available inside test files and
 `around_test` hooks before per-test fixtures are resolved. The generated
 fixture forces `RAILS_ENV` and `RACK_ENV` to `test` before Rails boots.
-`Smartest::Rails::TestServer` is only loaded by explicitly requiring
-`smartest/rails`; plain `require "smartest"` does not load Puma.
+`Smartest::Rack::TestServer` is only loaded by explicitly requiring
+`smartest/rack`; plain `require "smartest"` does not load Puma.
+Despite being used by the Rails scaffold, it accepts any Rack app via `app:`,
+including Sinatra, Hanami, and other Rack-compatible apps.
 
 This is aimed at local Rails system tests that combine Rails test data, stubs,
 and Playwright browser assertions. It is not a Capybara compatibility layer or
@@ -292,6 +294,10 @@ At runtime, set `PLAYWRIGHT_WS_ENDPOINT`,
 sidecar and gives the browser a Docker-network URL for Rails. These are usually
 stable Docker topology settings, so put them in `compose.yml` instead of
 repeating them on every `docker compose run` command.
+Because this path connects to Playwright over WebSocket, `websocket-driver` is
+**REQUIRED only when** using `PLAYWRIGHT_WS_ENDPOINT` or
+`Playwright.connect_to_browser_server`; local Rails browser tests that launch
+Playwright locally do not need it.
 For a Rails Compose service named `web`, use
 `SMARTEST_RAILS_BASE_URL=http://web:4001`; replace `web` with your service name.
 The generated Rails fixture sets `RAILS_ENV` and `RACK_ENV` to `test`, even if

--- a/documentation/docs/playwright-browser-tests.md
+++ b/documentation/docs/playwright-browser-tests.md
@@ -28,6 +28,11 @@ adds the `playwright-ruby-client` gem, installs the Playwright Node.js package
 and browsers, and creates example fixture / matcher / test files under
 `smartest/`.
 
+`websocket-driver` is **REQUIRED only when** connecting to a remote Playwright
+server with `PLAYWRIGHT_WS_ENDPOINT` or
+`Playwright.connect_to_browser_server`. The local scaffold path uses
+`Playwright.create` and does not need it.
+
 ### 2. Run the generated example test
 
 ```bash

--- a/documentation/docs/rails-browser-tests-with-docker.md
+++ b/documentation/docs/rails-browser-tests-with-docker.md
@@ -36,6 +36,16 @@ docker compose run --rm web bundle add smartest --group test
 docker compose build web
 ```
 
+The Docker sidecar setup connects to the Playwright server over WebSocket.
+`websocket-driver` is **REQUIRED only when** using `PLAYWRIGHT_WS_ENDPOINT` or
+`Playwright.connect_to_browser_server`; local Rails browser tests that launch
+Playwright locally do not need it.
+
+```bash
+docker compose run --rm web bundle add websocket-driver --group test
+docker compose build web
+```
+
 Prepare the Rails databases. From your host shell, run the commands through
 Compose so they use the same image and database service as the test run:
 
@@ -84,13 +94,13 @@ variables.
 
 ## Architecture
 
-![Two Docker Compose services. In the Rails web container (Alpine + Ruby + Node.js), the Smartest test runner boots Smartest::Rails::TestServer — which carries Rails.application bound to 0.0.0.0:3000 — and drives playwright-ruby-client. In the Playwright sidecar container (mcr.microsoft.com/playwright), PlaywrightServer drives Chromium, Firefox, and WebKit. The test runner reaches the browser over WebSocket (ws://playwright:8888/ws), and the browser reaches the Rails test server over HTTP (http://web:3000).](/img/rails-docker-architecture.png)
+![Two Docker Compose services. In the Rails web container (Alpine + Ruby + Node.js), the Smartest test runner boots Smartest::Rack::TestServer — which carries Rails.application bound to 0.0.0.0:3000 — and drives playwright-ruby-client. In the Playwright sidecar container (mcr.microsoft.com/playwright), PlaywrightServer drives Chromium, Firefox, and WebKit. The test runner reaches the browser over WebSocket (ws://playwright:8888/ws), and the browser reaches the Rails test server over HTTP (http://web:3000).](/img/rails-docker-architecture.png)
 
 In the Rails app container:
 
 - Smartest runs the test suite.
 - Rails boots in `RAILS_ENV=test`.
-- `Smartest::Rails::TestServer` starts `Rails.application` in the same Ruby
+- `Smartest::Rack::TestServer` starts `Rails.application` in the same Ruby
   process.
 - Fixtures create records, install stubs, and prepare application state.
 

--- a/documentation/docs/rails-browser-tests.md
+++ b/documentation/docs/rails-browser-tests.md
@@ -343,12 +343,12 @@ React, Vue, or other asynchronous UI behavior.
 ## How the generated Rails fixture works
 
 The generated Rails fixture starts `Rails.application` with
-`Smartest::Rails::TestServer`.
+`Smartest::Rack::TestServer`.
 
 ```ruby
 # frozen_string_literal: true
 
-require "smartest/rails"
+require "smartest/rack"
 require "playwright"
 
 ENV["RAILS_ENV"] = "test"
@@ -357,7 +357,7 @@ require_relative "../../config/environment"
 
 class RailsSystemTestFixture < Smartest::Fixture
   suite_fixture :rails_server do
-    server = Smartest::Rails::TestServer.new(
+    server = Smartest::Rack::TestServer.new(
       app: Rails.application,
       host: ENV["SMARTEST_RAILS_TEST_SERVER_HOST"],
       port: ENV["SMARTEST_RAILS_TEST_SERVER_PORT"],
@@ -429,8 +429,12 @@ class RailsSystemTestFixture < Smartest::Fixture
 end
 ```
 
-`Smartest::Rails::TestServer` is loaded only when `smartest/rails` is required.
+`Smartest::Rack::TestServer` is loaded only when `smartest/rack` is required.
 Plain `require "smartest"` does not load Puma.
+
+Despite being shown in the Rails scaffold, `Smartest::Rack::TestServer` accepts
+any Rack app via `app:`. For Sinatra, Hanami, or another Rack-compatible app,
+pass that app object instead of `Rails.application`.
 
 The generated fixture forces `RAILS_ENV` and `RACK_ENV` to `test`, then loads
 `config/environment` when `test_helper` requires the fixture file. That makes

--- a/lib/smartest/init_rails_generator.rb
+++ b/lib/smartest/init_rails_generator.rb
@@ -7,7 +7,7 @@ module Smartest
     RAILS_SYSTEM_FIXTURE = <<~RUBY
       # frozen_string_literal: true
 
-      require 'smartest/rails'
+      require 'smartest/rack'
       require "playwright"
 
       # Force the test environment and load Rails while test_helper is required
@@ -18,7 +18,7 @@ module Smartest
 
       class RailsSystemTestFixture < Smartest::Fixture
         suite_fixture :rails_server do
-          server = Smartest::Rails::TestServer.new(
+          server = Smartest::Rack::TestServer.new(
             app: Rails.application,
             host: ENV["SMARTEST_RAILS_TEST_SERVER_HOST"],
             port: ENV["SMARTEST_RAILS_TEST_SERVER_PORT"],

--- a/lib/smartest/rack.rb
+++ b/lib/smartest/rack.rb
@@ -7,7 +7,7 @@ require "timeout"
 require_relative "../smartest"
 
 module Smartest
-  module Rails
+  module Rack
     class TestServer
       DEFAULT_READY_TIMEOUT = 10
 
@@ -35,14 +35,14 @@ module Smartest
           sleep 0.05 until responsive?
         end
       rescue Timeout::Error
-        raise "Rails test server did not become ready at #{base_url} within #{timeout} seconds"
+        raise "Rack test server did not become ready at #{base_url} within #{timeout} seconds"
       end
 
       def wait_for_stopped(timeout: DEFAULT_READY_TIMEOUT)
         return unless @thread
         return if @thread.join(timeout)
 
-        raise "Rails test server did not stop within #{timeout} seconds"
+        raise "Rack test server did not stop within #{timeout} seconds"
       end
 
       def base_url
@@ -57,7 +57,7 @@ module Smartest
 
         return bound_port if bound_port && bound_port.positive?
 
-        raise "Rails test server could not determine bound port"
+        raise "Rack test server could not determine bound port"
       end
 
       def responsive?

--- a/smartest/smartest_test.rb
+++ b/smartest/smartest_test.rb
@@ -2290,13 +2290,13 @@ test("cli browser init generator skips npm init when package.json already exists
   end
 end
 
-test("smartest rails helper is loaded only by explicit require") do
+test("smartest rack helper is loaded only by explicit require") do
   lib_path = File.expand_path("../lib", __dir__)
   stdout, stderr, status = Open3.capture3(
     { "RUBYLIB" => lib_path },
     "ruby",
     "-e",
-    'require "smartest"; puts Smartest.const_defined?(:Rails, false)'
+    'require "smartest"; puts Smartest.const_defined?(:Rack, false)'
   )
 
   expect(status.success?).to eq(true)
@@ -2310,7 +2310,7 @@ test("smartest rails helper is loaded only by explicit require") do
       { "RUBYLIB" => "#{dir}:#{lib_path}" },
       "ruby",
       "-e",
-      'require "smartest/rails"; puts Smartest::Rails.const_defined?(:TestServer, false)'
+      'require "smartest/rack"; puts Smartest::Rack.const_defined?(:TestServer, false)'
     )
 
     expect(status.success?).to eq(true)
@@ -2319,7 +2319,7 @@ test("smartest rails helper is loaded only by explicit require") do
   end
 end
 
-test("smartest rails test server wraps puma with explicit arguments and lifecycle") do
+test("smartest rack test server wraps puma with explicit arguments and lifecycle") do
   lib_path = File.expand_path("../lib", __dir__)
 
   Dir.mktmpdir do |dir|
@@ -2367,10 +2367,10 @@ test("smartest rails test server wraps puma with explicit arguments and lifecycl
       "ruby",
       "-e",
       <<~'RUBY'
-        require "smartest/rails"
+        require "smartest/rack"
 
-        server = Smartest::Rails::TestServer.new(app: Object.new, port: "4567")
-        default_port_server = Smartest::Rails::TestServer.new(app: Object.new)
+        server = Smartest::Rack::TestServer.new(app: Object.new, port: "4567")
+        default_port_server = Smartest::Rack::TestServer.new(app: Object.new)
         thread = server.start
         server.stop
         server.wait_for_stopped
@@ -2411,7 +2411,7 @@ test("cli rails init generator creates Rails browser scaffold and installation c
 
     expect(status).to eq(0)
     rails_fixture = File.read(File.join(dir, "smartest/fixtures/rails_system_fixture.rb"))
-    expect(rails_fixture).to include("require 'smartest/rails'")
+    expect(rails_fixture).to include("require 'smartest/rack'")
     expect(rails_fixture).to include("class RailsSystemTestFixture < Smartest::Fixture")
     expect(rails_fixture).to include("suite_fixture :rails_server")
     expect(rails_fixture).to include('ENV["RAILS_ENV"] = "test"')
@@ -2420,7 +2420,7 @@ test("cli rails init generator creates Rails browser scaffold and installation c
     expect(rails_fixture).to include("constants are available before per-test fixtures are resolved")
     expect(rails_fixture).to include('require_relative "../../config/environment"')
     expect(rails_fixture.index('require_relative "../../config/environment"') < rails_fixture.index("class RailsSystemTestFixture")).to eq(true)
-    expect(rails_fixture).to include("Smartest::Rails::TestServer.new(")
+    expect(rails_fixture).to include("Smartest::Rack::TestServer.new(")
     expect(rails_fixture).to include('host: ENV["SMARTEST_RAILS_TEST_SERVER_HOST"]')
     expect(rails_fixture).not_to include("bind_host:")
     expect(rails_fixture).to include('port: ENV["SMARTEST_RAILS_TEST_SERVER_PORT"]')
@@ -2497,7 +2497,7 @@ test("cli rails init generator forces Rails test environment when the generated 
 
     stub_dir = File.join(dir, "stub_load_path")
     FileUtils.mkdir_p(File.join(stub_dir, "smartest"))
-    File.write(File.join(stub_dir, "smartest/rails.rb"), <<~RUBY)
+    File.write(File.join(stub_dir, "smartest/rack.rb"), <<~RUBY)
       module Smartest
         class Fixture
           def self.suite_fixture(*)
@@ -2507,7 +2507,7 @@ test("cli rails init generator forces Rails test environment when the generated 
           end
         end
 
-        module Rails
+        module Rack
         end
       end
     RUBY


### PR DESCRIPTION
resolves #46 

## Summary

- Rename the explicit test server helper from `Smartest::Rails::TestServer` / `smartest/rails` to `Smartest::Rack::TestServer` / `smartest/rack`.
- Update the Rails init scaffold, tests, README, and Docusaurus docs to use the Rack naming and document that the server accepts any Rack app.
- Document that `websocket-driver` is required only for remote Playwright server connections via `PLAYWRIGHT_WS_ENDPOINT` / `Playwright.connect_to_browser_server`, not local browser runs.

## Why

The server implementation wraps `Puma::Server` around the supplied `app:` object, so the public name should describe Rack behavior instead of implying Rails-only behavior. Because the project has no users yet, this PR makes the breaking rename directly instead of adding a compatibility alias.

## Validation

- `RBENV_VERSION=3.3.0 rbenv exec bundle exec rake test`
- `npm run build` from `documentation/`
